### PR TITLE
[WIP] New API proposal

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,6 +9,10 @@ extensions = [
     'numpydoc',
 ]
 
+autodoc_default_flags = ['members', 'inherited-members']
+
+default_role='any'
+
 templates_path = ['_templates']
 source_suffix = '.rst'
 master_doc = 'index'

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,17 +14,34 @@ This package contains efficient Python implementations of several popular
 metric learning algorithms.
 
 .. toctree::
-   :caption: Algorithms
+   :caption: Unsupervised Algorithms
    :maxdepth: 1
 
    metric_learn.covariance
-   metric_learn.lmnn
+
+.. toctree::
+   :caption: Weakly Supervised algorithms
+   :maxdepth: 1
+
+   metric_learn.weakly_supervised
+   metric_learn.mmc
    metric_learn.itml
    metric_learn.sdml
    metric_learn.lsml
+
+Note that all Weakly Supervised Metric Learners have a supervised version. See
+:ref:`this section<supervised_version>` for more details.
+
+
+.. toctree::
+   :caption: Supervised algorithms
+   :maxdepth: 1
+
+   metric_learn.lmnn
    metric_learn.nca
    metric_learn.lfda
    metric_learn.rca
+   metric_learn.mlkr
 
 Each metric supports the following methods:
 
@@ -34,6 +51,9 @@ Each metric supports the following methods:
    data matrix :math:`X \in \mathbb{R}^{n \times d}` to the
    :math:`D`-dimensional learned metric space :math:`X L^{\top}`,
    in which standard Euclidean distances may be used.
+
+.. _transform_ml:
+
 -  ``transform(X)``, which applies the aforementioned transformation.
 -  ``metric()``, which returns a Mahalanobis matrix
    :math:`M = L^{\top}L` such that distance between vectors ``x`` and

--- a/doc/metric_learn.base_metric.rst
+++ b/doc/metric_learn.base_metric.rst
@@ -5,3 +5,4 @@ metric_learn.base_metric module
     :members:
     :undoc-members:
     :show-inheritance:
+

--- a/doc/metric_learn.constrained_dataset.rst
+++ b/doc/metric_learn.constrained_dataset.rst
@@ -1,0 +1,8 @@
+ConstrainedDataset
+==================
+
+.. autoclass:: metric_learn.constraints.ConstrainedDataset
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/doc/metric_learn.weakly_supervised.rst
+++ b/doc/metric_learn.weakly_supervised.rst
@@ -1,0 +1,220 @@
+.. _wsml:
+
+Weakly Supervised Learning (General information)
+================================================
+
+Introduction
+------------
+
+In Distance Metric Learning, we are interested in learning a metric between
+points that takes into account some supervised information about the
+similarity between those points. If each point has a class, we can use this
+information by saying that all intra-class points are similar, and inter-class
+points are dissimilar.
+
+However, sometimes we do not have a class for each sample. Instead, we can have
+pairs of points and a label for each saying whether the points in each pair are
+similar or not. Indeed, if we imagine a hand labeled dataset of images with a
+huge number of classes, it will be easier for a human to say whether two images
+are similar rather that telling, among the huge number of classes, which one is
+that of the shown image. We can also have a dataset of triplets of points where
+we know the first sample is more similar to the second than the third. Or we
+could also have quadruplets of points where the two first points are more
+similar than the two last are. In fact, some metric learning algorithms are
+made to use this kind of data. These are Weakly Supervised Metric Learners. For
+instance, `ITML`, `MMC` and `SDML` work on labeled pairs, and `LSML` works on
+unlabeled quadruplets.
+
+In the ``metric-learn`` package, we use an object called `ConstrainedDataset`
+to store these kinds of datasets where each sample/line is a tuple of points
+from an initial dataset. Contrary to a 3D numpy array where each line would be
+a tuple of ``t`` points from an initial dataset,  `ConstrainedDataset` is
+memory efficient as it does not duplicate points in the underlying memory.
+Instead, it stores indices of points involved in every tuple, as well as the
+initial dataset. Plus, it supports slicing on tuples to be compatible with
+scikit-learn utilities for cross-validation (see :ref:`performance_ws`).
+
+See documentation of `ConstrainedDataset` `here<ConstrainedDataset>` for more
+information.
+
+
+
+.. _workflow_ws:
+
+Basic worflow
+-------------
+
+Let us see how we can use weakly supervised metric learners in a basic
+scikit-learn like workflow with ``fit``, ``predict``, ``transform``,
+``score`` etc.
+
+- Fitting
+
+Let's say we have a dataset of samples and we also know for some pairs of them
+if they are similar of dissimilar. We want to fit a metric learner on this
+data. First, we recognize this data is made of labeled pairs. What we will need
+to do first is therefore to make a `ConstrainedDataset` with as input the
+points ``X`` (an array of shape ``(n_samples, n_features)``, and the
+constraints ``c`` (an array of shape ``(n_constraints, 2))`` of indices of
+pairs. We also need to have a vector ``y_constraints`` of shape
+``(n_constraints,)`` where each ``y_constraints_i`` is 1 if sample
+``X[c[i,0]]`` is similar to sample ``X[c[i, 1]]`` and 0 if they are dissimilar.
+
+.. code:: python
+
+    from metric_learn import ConstrainedDataset
+    X_constrained = ConstrainedDataset(X, c)
+
+Then we can fit a Weakly Supervised Metric Learner (here that inherits from
+`PairsMixin`), on this data (let's use `MMC` for instance):
+
+.. code:: python
+
+    from metric_learn import MMC
+    mmc = MMC()
+    mmc.fit(X_constrained, y_constraints)
+
+.. _transform_ws:
+
+- Transforming
+
+Weakly supervised metric learners can also be used as transformers. Let us say
+we have a fitted estimator. At ``transform`` time, they can independently be
+used on arrays of samples as well as `ConstrainedDataset`s. Indeed, they will
+return transformed samples and thus only need input samples (they will ignore
+any information on constraints in the input). The transformed samples are the
+new points in an embedded space.  See :ref:`this section<transform_ml>` for
+more details about this transformation.
+
+.. code:: python
+
+    mmc.transform(X)
+
+- Predicting
+
+Weakly Supervised Metric Learners work on lines of data where each line is a
+tuple of points of an original dataset. For some of these, we should also have
+a label for each line (for instance in the cases of learning on pairs, each
+label ``y_constraints_i`` should tell whether the pair in line ``i`` is a
+similar or dissimilar pair). So for these algorithm, applying ``predict`` to an
+input ConstrainedDataset will predict scalars related to this task for each
+tuple. For instance in the case of pairs, ``predict`` will return for each
+input pair a float measuring the similarity between samples in the pair.
+
+See the API documentation for `WeaklySupervisedMixin`'s childs
+( `PairsMixin`,
+`TripletsMixin`, `QuadrupletsMixin`) for the particular prediction functions of
+each type of Weakly Supervised Metric Learner.
+
+.. code:: python
+
+    mmc.predict(X_constrained)
+
+- Scoring
+
+We can also use scoring functions like this, calling the default scoring
+function of the Weakly Supervised Learner we use:
+
+.. code:: python
+
+    mmc.score(X_constrained, y_constraints)
+
+The type of score depends on the type of Weakly Supervised Metric Learner
+used. See the API documentation for `WeaklySupervisedMixin`'s childs
+(`PairsMixin`, `TripletsMixin`, `QuadrupletsMixin`) for the particular
+default scoring functions of each type of estimator.
+
+See also :ref:`performance_ws`, for how to use scikit-learn's
+cross-validation routines with Weakly Supervised Metric Learners.
+
+
+.. _supervised_version:
+
+Supervised Version
+------------------
+
+Weakly Supervised Metric Learners can also be used in a supervised way: the
+corresponding supervised algorithm will create a
+`ConstrainedDataset` ``X_constrained``
+and labels
+``y_constraints`` of tuples from a supervised dataset with labels. For
+instance if we want to use the algorithm `MMC` on a dataset of points and
+labels
+(``X`` and ``y``),
+we should use ``MMC_Supervised`` (the underlying code will create pairs of
+samples from the same class and labels saying that they are similar, and pairs
+of samples from a different class and labels saying that they are
+dissimilar, before calling `MMC`).
+
+Example:
+
+.. code:: python
+
+    from sklearn.datasets import make_classification
+
+    X, y = make_classification()
+    mmc_supervised = MMC_Supervised()
+    mmc_supervised.fit_transform(X, y)
+
+
+.. _performance_ws:
+
+Evaluating the performance of weakly supervised metric learning algorithms
+--------------------------------------------------------------------------
+
+To evaluate the performance of a classical supervised algorithm that takes in
+an input dataset ``X`` and some labels ``y``, we can compute a cross-validation
+score. However, weakly supervised algorithms cannot  ``predict`` on one sample,
+so we cannot split on samples to make a training set and a test set the same
+way as we do with usual estimators. Instead, metric learning algorithms output
+a score on a **tuple** of samples: for instance a similarity score on pairs of
+samples. So doing cross-validation scoring for metric learning algorithms
+implies to split on **tuples** of samples. Hopefully, `ConstrainedDataset`
+allows to do so naturally.
+
+Here is how we would get the cross-validation score for the ``MMC`` algorithm:
+
+.. code:: python
+
+    from sklearn.model_selection import cross_val_score
+    cross_val_score(mmc, X_constrained, y_constraints)
+
+
+Pipelining
+----------
+
+Weakly Supervised Learners can also be embedded in scikit-learn pipelines.
+However, they can only be combined with Transformers. This is because there
+is already supervision from constraints and we cannot add more
+supervision that would be used from scikit-learn's supervised estimators.
+
+For instance, you can combine it with another transformer like PCA or KMeans:
+
+.. code:: python
+
+    from sklearn.decomposition import PCA
+    from sklearn.clustering import KMeans
+    from sklearn.pipeline import make_pipeline
+
+    pipe_pca = make_pipeline(MMC(), PCA())
+    pipe_pca.fit(X_constrained, y)
+    pipe_clustering = make_pipeline(MMC(), KMeans())
+    pipe_clustering.fit(X_constrained, y)
+
+There are also some other things to keep in mind:
+
+- The ``X`` type input of the pipeline should be a `ConstrainedDataset` when
+  fitting, but when transforming or predicting it can be an array of samples.
+  Therefore, all the following lines are valid:
+
+  .. code:: python
+
+      pipe_pca.transform(X_constrained)
+      pipe_pca.fit_transform(X_constrained)
+      pipe_pca.transform(X_constrained.X)
+
+- You should also not try to cross-validate those pipelines with scikit-learn's
+  cross-validation functions (as their input data is a `ConstrainedDataset`
+  which when splitting can contain same points between train and test (but
+  of course not the same tuple of points)).
+

--- a/metric_learn/__init__.py
+++ b/metric_learn/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from .constraints import Constraints
+from .constraints import Constraints, ConstrainedDataset
 from .covariance import Covariance
 from .itml import ITML, ITML_Supervised
 from .lmnn import LMNN

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -59,7 +59,7 @@ class SupervisedMetricLearner(BaseMetricLearner):
 
 class WeaklySupervisedMetricLearner(BaseMetricLearner):
 
-  def fit(self, constrained_dataset, y):
+  def fit(self, X_constrained, y):
     return NotImplementedError
 
 

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -3,7 +3,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_array
 
 
-class BaseMetricLearner(BaseEstimator):
+class BaseMetricLearner(BaseEstimator, TransformerMixin):
   def __init__(self):
     raise NotImplementedError('BaseMetricLearner should not be instantiated')
 
@@ -51,7 +51,7 @@ class BaseMetricLearner(BaseEstimator):
     return X.dot(L.T)
 
 
-class SupervisedMetricLearner(BaseMetricLearner, TransformerMixin):
+class SupervisedMetricLearner(BaseMetricLearner):
 
   def fit(self, X, y):
     return NotImplementedError

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -2,14 +2,11 @@ from numpy.linalg import cholesky
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_array
 
-
-class TransformerMixin(object):
-  """Mixin class for all transformers in metric-learn. Same as the one in
-  scikit-learn, but the documentation is changed: this Transformer is
-  allowed to take as y a non array-like input"""
+class BaseMetricLearner(BaseEstimator):
 
   def __init__(self):
-    raise NotImplementedError('TransformerMixin should not be instantiated')
+    raise NotImplementedError('BaseMetricLearner should not be instantiated')
+
 
   def fit_transform(self, X, y=None, **fit_params):
     """Fit to data, then transform it.
@@ -19,7 +16,7 @@ class TransformerMixin(object):
 
     Parameters
     ----------
-    X : numpy array of shape [n_samples, n_features]
+    X : array-like of shape [n_samples, n_features], or ConstrainedDataset
         Training set.
 
     y : numpy array of shape [n_samples] or 4-tuple of arrays
@@ -40,11 +37,6 @@ class TransformerMixin(object):
     else:
       # fit method of arity 2 (supervised transformation)
       return self.fit(X, y, **fit_params).transform(X)
-
-class BaseMetricLearner(BaseEstimator, TransformerMixin):
-
-  def __init__(self):
-    raise NotImplementedError('BaseMetricLearner should not be instantiated')
 
   def metric(self):
     """Computes the Mahalanobis matrix from the transformation matrix.

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -119,10 +119,13 @@ class TripletsMixin(WeaklySupervisedMixin):
   # TODO: introduce specific scoring functions etc
 
 
-class QuadrupletsMixin(UnsupervisedMixin):
+class QuadrupletsMixin(WeaklySupervisedMixin):
 
   def __init__(self):
     raise NotImplementedError('QuadrupletsMixin should not be '
                               'instantiated')
   # TODO: introduce specific scoring functions etc
+
+  def fit(self, X, constraints=None, **kwargs):
+    return self._fit(X, **kwargs)
 

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -1,7 +1,42 @@
-from numpy.linalg import inv, cholesky
-from sklearn.base import BaseEstimator, TransformerMixin
+from numpy.linalg import cholesky
+from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_array
 
+
+class TransformerMixin(object):
+  """Mixin class for all transformers in metric-learn. Same as the one in
+  scikit-learn, but the documentation is changed: this Transformer is
+  allowed to take as y a non array-like input"""
+
+  def fit_transform(self, X, y=None, **fit_params):
+    """Fit to data, then transform it.
+
+    Fits transformer to X and y with optional parameters fit_params
+    and returns a transformed version of X.
+
+    Parameters
+    ----------
+    X : numpy array of shape [n_samples, n_features]
+        Training set.
+
+    y : numpy array of shape [n_samples] or 4-tuple of arrays
+        Target values, or constraints (a, b, c, d) indices into X, with
+        (a, b) specifying similar and (c,d) dissimilar pairs).
+
+    Returns
+    -------
+    X_new : numpy array of shape [n_samples, n_features_new]
+        Transformed array.
+
+    """
+    # non-optimized default implementation; override when a better
+    # method is possible for a given clustering algorithm
+    if y is None:
+      # fit method of arity 1 (unsupervised transformation)
+      return self.fit(X, **fit_params).transform(X)
+    else:
+      # fit method of arity 2 (supervised transformation)
+      return self.fit(X, y, **fit_params).transform(X)
 
 class BaseMetricLearner(BaseEstimator, TransformerMixin):
   def __init__(self):
@@ -51,35 +86,43 @@ class BaseMetricLearner(BaseEstimator, TransformerMixin):
     return X.dot(L.T)
 
 
-class SupervisedMetricLearner(BaseMetricLearner):
+class SupervisedMixin(object):
 
   def fit(self, X, y):
     return NotImplementedError
 
 
-class WeaklySupervisedMetricLearner(BaseMetricLearner):
+class UnsupervisedMixin(object):
 
-  def fit(self, X_constrained, y):
+  def fit(self, X, y=None):
     return NotImplementedError
 
 
-class PairsMetricLearner(WeaklySupervisedMetricLearner):
+class WeaklySupervisedMixin(object):
+
+  def fit(self, X, constraints, **kwargs):
+    return self._fit(X, constraints, **kwargs)
+
+
+class PairsMixin(WeaklySupervisedMixin):
 
   def __init__(self):
-    raise NotImplementedError('PairsMetricLearner should not be instantiated')
+    raise NotImplementedError('PairsMixin should not be instantiated')
   # TODO: introduce specific scoring functions etc
 
 
-class TripletsMetricLearner(WeaklySupervisedMetricLearner):
+class TripletsMixin(WeaklySupervisedMixin):
 
   def __init__(self):
-    raise NotImplementedError('TripletsMetricLearner should not be '
+    raise NotImplementedError('TripletsMixin should not be '
                               'instantiated')
   # TODO: introduce specific scoring functions etc
 
-class QuadrupletsMetricLearner(WeaklySupervisedMetricLearner):
+
+class QuadrupletsMixin(UnsupervisedMixin):
 
   def __init__(self):
-    raise NotImplementedError('QuadrupletsMetricLearner should not be '
+    raise NotImplementedError('QuadrupletsMixin should not be '
                               'instantiated')
   # TODO: introduce specific scoring functions etc
+

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -3,7 +3,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_array
 
 
-class BaseMetricLearner(BaseEstimator, TransformerMixin):
+class BaseMetricLearner(BaseEstimator):
   def __init__(self):
     raise NotImplementedError('BaseMetricLearner should not be instantiated')
 
@@ -49,3 +49,31 @@ class BaseMetricLearner(BaseEstimator, TransformerMixin):
       X = check_array(X, accept_sparse=True)
     L = self.transformer()
     return X.dot(L.T)
+
+
+class SupervisedMetricLearner(BaseMetricLearner, TransformerMixin):
+
+  def fit(self, X, y):
+    return NotImplementedError
+
+
+class WeaklySupervisedMetricLearner(BaseMetricLearner):
+
+  def fit(self, X, constraints):
+    return NotImplementedError
+
+
+class PairsMetricLearner(WeaklySupervisedMetricLearner):
+
+  def __init__(self):
+    raise NotImplementedError('PairsMetricLearner should not be instantiated')
+  # TODO: introduce specific scoring functions etc
+
+
+class TripletsMetricLearner(WeaklySupervisedMetricLearner):
+
+  def __init__(self):
+    raise NotImplementedError('TripletsMetricLearner should not be '
+                              'instantiated')
+  # TODO: introduce specific scoring functions etc
+

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -8,6 +8,9 @@ class TransformerMixin(object):
   scikit-learn, but the documentation is changed: this Transformer is
   allowed to take as y a non array-like input"""
 
+  def __init__(self):
+    raise NotImplementedError('TransformerMixin should not be instantiated')
+
   def fit_transform(self, X, y=None, **fit_params):
     """Fit to data, then transform it.
 
@@ -39,6 +42,7 @@ class TransformerMixin(object):
       return self.fit(X, y, **fit_params).transform(X)
 
 class BaseMetricLearner(BaseEstimator, TransformerMixin):
+
   def __init__(self):
     raise NotImplementedError('BaseMetricLearner should not be instantiated')
 
@@ -88,17 +92,27 @@ class BaseMetricLearner(BaseEstimator, TransformerMixin):
 
 class SupervisedMixin(object):
 
+  def __init__(self):
+    raise NotImplementedError('UnsupervisedMixin should not be instantiated')
+
   def fit(self, X, y):
     return NotImplementedError
 
 
 class UnsupervisedMixin(object):
 
+  def __init__(self):
+    raise NotImplementedError('UnsupervisedMixin should not be instantiated')
+
   def fit(self, X, y=None):
     return NotImplementedError
 
 
 class WeaklySupervisedMixin(object):
+
+  def __init__(self):
+    raise NotImplementedError('WeaklySupervisedMixin should not be '
+                              'instantiated')
 
   def fit(self, X, constraints, **kwargs):
     return self._fit(X, constraints, **kwargs)

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -127,8 +127,8 @@ class PairsMixin(WeaklySupervisedMixin):
 
   def predict(self, X_constrained):
     # TODO: provide better implementation
-    pairwise_diffs = X_constrained.X[X_constrained.c[:, 0]] - \
-                     X_constrained.X[X_constrained.c[:, 1]]
+    pairwise_diffs = (X_constrained.X[X_constrained.c[:, 0]] -
+                      X_constrained.X[X_constrained.c[:, 1]])
     return np.sqrt(np.sum(pairwise_diffs.dot(self.metric()) * pairwise_diffs,
                                   axis=1))
 

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -59,7 +59,7 @@ class SupervisedMetricLearner(BaseMetricLearner):
 
 class WeaklySupervisedMetricLearner(BaseMetricLearner):
 
-  def fit(self, X, constraints):
+  def fit(self, constrained_dataset, y):
     return NotImplementedError
 
 
@@ -77,3 +77,9 @@ class TripletsMetricLearner(WeaklySupervisedMetricLearner):
                               'instantiated')
   # TODO: introduce specific scoring functions etc
 
+class QuadrupletsMetricLearner(WeaklySupervisedMetricLearner):
+
+  def __init__(self):
+    raise NotImplementedError('QuadrupletsMetricLearner should not be '
+                              'instantiated')
+  # TODO: introduce specific scoring functions etc

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -105,10 +105,10 @@ class ConstrainedDataset(object):
   Parameters
   ----------
   X: array-like, shape=(n_samples, n_features)
-        Dataset of samples.
+    Dataset of samples.
 
   c: array-like of integers between 0 and n_samples, shape=(n_constraints, t)
-        Array of indexes of the ``t`` samples to consider in each constraint.
+    Array of indexes of the ``t`` samples to consider in each constraint.
 
   Attributes
   ----------

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -93,6 +93,57 @@ class Constraints(object):
 
 
 class ConstrainedDataset(object):
+  """Constrained Dataset
+
+  This is what weakly supervised metric learning algorithms take as input. It
+  wraps a dataset ``X`` and some constraints ``c``. It mocks a 3D array of
+  shape ``(n_constraints, t, n_features)``, where each line contains t
+  samples from ``X``.
+
+  Read more in the :ref:`User Guide <wsml>`.
+
+  Parameters
+  ----------
+  X: array-like, shape=(n_samples, n_features)
+        Dataset of samples.
+
+  c: array-like or integers between 0 and n_samples, shape=(n_constraints, t)
+        Array of indexes of the ``t`` samples to consider in each constraint.
+
+  Attributes
+  ----------
+  X: array-like, shape=(n_samples, n_features)
+    The dataset ``X`` stored in the `ConstrainedDataset`.
+
+  c: array-like, shape=(n_constraints, t)
+    The current array of indices that is stored in the `ConstrainedDataset`.
+
+  shape: tuple, len==3.
+    The shape of the `ConstrainedDataset`. It is (n_constraints, t,
+    n_features), where ``t`` is the number of samples in each tuple.
+
+  Examples
+  --------
+  X is a regular array-like dataset, with 4 samples of 3 features each. Let
+  us say we also have pair constraints.
+
+  >>> X = [[1., 5., 6.], [7., 5., 2.], [9., 2., 0.], [2., 8., 4.]]
+  >>> constraints = [[0, 2], [1, 3], [2, 3]]
+
+  The first element of the new dataset will be the pair of sample 0 and
+  sample 2. We can later have a labels array ``y_constraints`` which will
+  say if this pair is positive (similar samples) or negative.
+
+  >>> X_constrained = ConstrainedDataset(X, constraints)
+  >>> X_constrained.toarray()
+  array([[[ 1.,  5.,  6.],
+          [ 9.,  2.,  0.]],
+         [[ 7.,  5.,  2.],
+          [ 2.,  8.,  4.]],
+         [[ 9.,  2.,  0.],
+          [ 2.,  8.,  4.]]])
+
+  """
 
   def __init__(self, X, c):
     # we convert the data to a suitable format
@@ -104,7 +155,9 @@ class ConstrainedDataset(object):
                          ensure_2d=False, ensure_min_samples=False,
                          ensure_min_features=False, warn_on_dtype=True)
     self._check_index(self.X.shape[0], self.c)
-    self.shape = (len(c) if hasattr(c, '__len__') else 0, self.X.shape[1])
+    self.shape = (len(c) if hasattr(c, '__len__') else 0, self.c.shape[1] if
+    (len(self.c.shape) > 1 if hasattr(c, 'shape') else 0) else 0,
+                  self.X.shape[1])
 
   def __getitem__(self, item):
     return ConstrainedDataset(self.X, self.c[item])

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -146,12 +146,12 @@ class ConstrainedDataset(object):
     raise NotImplementedError
 
 
-def unwrap_pairs(constrained_dataset, y):
-  a = constrained_dataset.c[(y == 0)[:, 0]][:, 0]
-  b = constrained_dataset.c[(y == 0)[:, 0]][:, 1]
-  c = constrained_dataset.c[(y == 1)[:, 0]][:, 0]
-  d = constrained_dataset.c[(y == 1)[:, 0]][:, 1]
-  X = constrained_dataset.X
+def unwrap_pairs(X_constrained, y):
+  a = X_constrained.c[(y == 0)[:, 0]][:, 0]
+  b = X_constrained.c[(y == 0)[:, 0]][:, 1]
+  c = X_constrained.c[(y == 1)[:, 0]][:, 0]
+  d = X_constrained.c[(y == 1)[:, 0]][:, 1]
+  X = X_constrained.X
   return X, [a, b, c, d]
 
 def wrap_pairs(X, constraints):
@@ -162,16 +162,16 @@ def wrap_pairs(X, constraints):
   constraints = np.vstack([np.hstack([a[:, None], b[:, None]]),
                            np.hstack([c[:, None], d[:, None]])])
   y = np.vstack([np.zeros((len(a), 1)), np.ones((len(c), 1))])
-  constrained_dataset = ConstrainedDataset(X, constraints)
-  return constrained_dataset, y
+  X_constrained = ConstrainedDataset(X, constraints)
+  return X_constrained, y
 
-def unwrap_to_graph(constrained_dataset, y):
+def unwrap_to_graph(X_constrained, y):
 
-  X, [a, b, c, d] = unwrap_pairs(constrained_dataset, y)
+  X, [a, b, c, d] = unwrap_pairs(X_constrained, y)
   row = np.concatenate((a, c))
   col = np.concatenate((b, d))
   data = np.ones_like(row, dtype=int)
   data[len(a):] = -1
-  adj = coo_matrix((data, (row, col)), shape=(constrained_dataset.X.shape[0],)
+  adj = coo_matrix((data, (row, col)), shape=(X_constrained.X.shape[0],)
                                              * 2)
-  return constrained_dataset.X, adj + adj.T
+  return X_constrained.X, adj + adj.T

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -5,7 +5,7 @@ from supervised data labels.
 import numpy as np
 import warnings
 from six.moves import xrange
-from scipy.sparse import coo_matrix
+from scipy.sparse import coo_matrix, issparse
 from sklearn.utils import check_array
 
 __all__ = ['Constraints', 'ConstrainedDataset']
@@ -172,7 +172,12 @@ class ConstrainedDataset(object):
     return self.toarray().__repr__()
 
   def toarray(self):
-    return self.X[self.c]
+    if issparse(self.X):
+      # if X is sparse we convert it to dense because sparse arrays cannot
+      # be 3D
+      return self.X.A[self.c]
+    else:
+      return self.X[self.c]
 
   @staticmethod
   def _check_index(length, indices):

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -5,7 +5,7 @@ from supervised data labels.
 import numpy as np
 import warnings
 from six.moves import xrange
-from scipy.sparse import coo_matrix
+from scipy.sparse import coo_matrix, csr_matrix
 
 __all__ = ['Constraints']
 
@@ -100,3 +100,47 @@ class Constraints(object):
     partial_labels = np.array(all_labels, copy=True)
     partial_labels[idx] = -1
     return Constraints(partial_labels)
+
+
+  class ConstrainedDataset(object):
+
+    def __init__(self, X, c):
+      self.c = c
+      self.X = X
+      self.shape = (len(c), X.shape[1])
+
+    def __getitem__(self, item):
+      # Note that to avoid useless memory consumption, when splitting we
+      # delete the points that are not used
+      # TODO: deal with different types of slices (lists, arrays etc)
+      c_sliced = self.c[item]
+      unique_array = np.unique(c_sliced)
+      pruned_X = self.X[unique_array]
+      # We build an inverted index to find the new indices of pairs after
+      # having filtered some Xs out.
+      inverted_index = np.zeros((np.max(unique_array) + 1,), dtype=int)
+      inverted_index[unique_array] = np.arange(len(unique_array))
+      rescaled_sliced_c = inverted_index[c_sliced]
+      return self.__init__(pruned_X, rescaled_sliced_c)
+
+    def __len__(self):
+      return self.shape
+
+    def __str__(self):
+      return self.asarray().__str__()
+
+    def __repr__(self):
+      return self.asarray().__repr__()
+
+    def asarray(self):
+      return self.X[self.c]
+
+    @staticmethod
+    def pairs_from_labels(y):
+      # TODO: to be implemented
+      return NotImplementedError
+
+    @staticmethod
+    def triplets_from_labels(y):
+      # TODO: to be implemented
+      return NotImplementedError

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -96,7 +96,7 @@ class ConstrainedDataset(object):
 
   def __init__(self, X, c):
     # we convert the data to a suitable format
-    self.X = check_array(X, accept_sparse=True, dtype=None, warn_on_dtype=True)
+    self.X = check_array(X, accept_sparse=True, warn_on_dtype=True)
     self.c = check_array(c, dtype=['int'] + np.sctypes['int']
                                   + np.sctypes['uint'],
                          # we add 'int' at the beginning to tell it is the
@@ -110,7 +110,7 @@ class ConstrainedDataset(object):
     return ConstrainedDataset(self.X, self.c[item])
 
   def __len__(self):
-    return self.shape
+    return self.shape[0]
 
   def __str__(self):
     return self.toarray().__str__()

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -107,7 +107,7 @@ class ConstrainedDataset(object):
   X: array-like, shape=(n_samples, n_features)
         Dataset of samples.
 
-  c: array-like or integers between 0 and n_samples, shape=(n_constraints, t)
+  c: array-like of integers between 0 and n_samples, shape=(n_constraints, t)
         Array of indexes of the ``t`` samples to consider in each constraint.
 
   Attributes

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -158,8 +158,7 @@ def wrap_pairs(X, constraints):
   b = np.array(constraints[1])
   c = np.array(constraints[2])
   d = np.array(constraints[3])
-  constraints = np.vstack([np.hstack([a[:, None], b[:, None]]),
-                           np.hstack([c[:, None], d[:, None]])])
+  constraints = np.vstack((np.column_stack((a, b)), np.column_stack((c, d))))
   y = np.vstack([np.zeros((len(a), 1)), np.ones((len(c), 1))])
   X_constrained = ConstrainedDataset(X, constraints)
   return X_constrained, y

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -108,8 +108,8 @@ class ConstrainedDataset(object):
   def __init__(self, X, c):
     # we convert the data to a suitable format
     self.X = check_array(X, accept_sparse=True, dtype=None, warn_on_dtype=True)
-    self.c = check_array(c, dtype=['int', *np.sctypes['int'],
-                                   *np.sctypes['uint']],
+    self.c = check_array(c, dtype=['int'] + np.sctypes['int']
+                                  + np.sctypes['uint'],
                          # we add 'int' at the beginning to tell it is the
                          # default format we want in case of conversion
                          ensure_2d=False, ensure_min_samples=False,

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -19,17 +19,6 @@ class Constraints(object):
     self.known_label_idx, = np.where(partial_labels >= 0)
     self.known_labels = partial_labels[self.known_label_idx]
 
-  def adjacency_matrix(self, num_constraints, random_state=np.random):
-    a, b, c, d = self.positive_negative_pairs(num_constraints,
-                                              random_state=random_state)
-    row = np.concatenate((a, c))
-    col = np.concatenate((b, d))
-    data = np.ones_like(row, dtype=int)
-    data[len(a):] = -1
-    adj = coo_matrix((data, (row, col)), shape=(self.num_points,)*2)
-    # symmetrize
-    return adj + adj.T
-
   def positive_negative_pairs(self, num_constraints, same_length=False,
                               random_state=np.random):
     a, b = self._pairs(num_constraints, same_label=True,
@@ -155,3 +144,34 @@ class ConstrainedDataset(object):
   def triplets_from_labels(y):
     # TODO: to be implemented
     raise NotImplementedError
+
+
+def unwrap_pairs(constrained_dataset, y):
+  a = constrained_dataset.c[(y == 0)[:, 0]][:, 0]
+  b = constrained_dataset.c[(y == 0)[:, 0]][:, 1]
+  c = constrained_dataset.c[(y == 1)[:, 0]][:, 0]
+  d = constrained_dataset.c[(y == 1)[:, 0]][:, 1]
+  X = constrained_dataset.X
+  return X, [a, b, c, d]
+
+def wrap_pairs(X, constraints):
+  a = np.array(constraints[0])
+  b = np.array(constraints[1])
+  c = np.array(constraints[2])
+  d = np.array(constraints[3])
+  constraints = np.vstack([np.hstack([a[:, None], b[:, None]]),
+                           np.hstack([c[:, None], d[:, None]])])
+  y = np.vstack([np.zeros((len(a), 1)), np.ones((len(c), 1))])
+  constrained_dataset = ConstrainedDataset(X, constraints)
+  return constrained_dataset, y
+
+def unwrap_to_graph(constrained_dataset, y):
+
+  X, [a, b, c, d] = unwrap_pairs(constrained_dataset, y)
+  row = np.concatenate((a, c))
+  col = np.concatenate((b, d))
+  data = np.ones_like(row, dtype=int)
+  data[len(a):] = -1
+  adj = coo_matrix((data, (row, col)), shape=(constrained_dataset.X.shape[0],)
+                                             * 2)
+  return constrained_dataset.X, adj + adj.T

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -147,10 +147,9 @@ class ConstrainedDataset(object):
 
 
 def unwrap_pairs(X_constrained, y):
-  a = X_constrained.c[(y == 0)[:, 0]][:, 0]
-  b = X_constrained.c[(y == 0)[:, 0]][:, 1]
-  c = X_constrained.c[(y == 1)[:, 0]][:, 0]
-  d = X_constrained.c[(y == 1)[:, 0]][:, 1]
+  y_zero = (y == 0).ravel()
+  a, b = X_constrained.c[y_zero].T
+  c, d = X_constrained.c[~y_zero].T
   X = X_constrained.X
   return X, [a, b, c, d]
 

--- a/metric_learn/covariance.py
+++ b/metric_learn/covariance.py
@@ -15,14 +15,14 @@ from sklearn.utils.validation import check_array
 from .base_metric import BaseMetricLearner, UnsupervisedMixin
 
 
-class _Covariance(BaseMetricLearner):
+class Covariance(BaseMetricLearner, UnsupervisedMixin):
   def __init__(self):
     pass
 
   def metric(self):
     return self.M_
 
-  def _fit(self, X, y=None):
+  def fit(self, X, y=None):
     """
     X : data matrix, (n x d)
     y : unused
@@ -34,8 +34,3 @@ class _Covariance(BaseMetricLearner):
     else:
       self.M_ = np.linalg.inv(self.M_)
     return self
-
-class Covariance(_Covariance, UnsupervisedMixin):
-
-  def fit(self, X, y=None):
-    return self._fit(X, y)

--- a/metric_learn/covariance.py
+++ b/metric_learn/covariance.py
@@ -12,17 +12,17 @@ from __future__ import absolute_import
 import numpy as np
 from sklearn.utils.validation import check_array
 
-from .base_metric import SupervisedMetricLearner
+from .base_metric import BaseMetricLearner, UnsupervisedMixin
 
 
-class Covariance(SupervisedMetricLearner):
+class _Covariance(BaseMetricLearner):
   def __init__(self):
     pass
 
   def metric(self):
     return self.M_
 
-  def fit(self, X, y=None):
+  def _fit(self, X, y=None):
     """
     X : data matrix, (n x d)
     y : unused
@@ -34,3 +34,8 @@ class Covariance(SupervisedMetricLearner):
     else:
       self.M_ = np.linalg.inv(self.M_)
     return self
+
+class Covariance(_Covariance, UnsupervisedMixin):
+
+  def fit(self, X, y=None):
+    return self._fit(X, y)

--- a/metric_learn/covariance.py
+++ b/metric_learn/covariance.py
@@ -12,10 +12,10 @@ from __future__ import absolute_import
 import numpy as np
 from sklearn.utils.validation import check_array
 
-from .base_metric import BaseMetricLearner
+from .base_metric import SupervisedMetricLearner
 
 
-class Covariance(BaseMetricLearner):
+class Covariance(SupervisedMetricLearner):
   def __init__(self):
     pass
 

--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -19,12 +19,12 @@ from six.moves import xrange
 from sklearn.metrics import pairwise_distances
 from sklearn.utils.validation import check_array, check_X_y
 
-from .base_metric import BaseMetricLearner
+from .base_metric import PairsMetricLearner, SupervisedMetricLearner
 from .constraints import Constraints
 from ._util import vector_norm
 
 
-class ITML(BaseMetricLearner):
+class ITML(PairsMetricLearner):
   """Information Theoretic Metric Learning (ITML)"""
   def __init__(self, gamma=1., max_iter=1000, convergence_threshold=1e-3,
                A0=None, verbose=False):
@@ -140,7 +140,7 @@ class ITML(BaseMetricLearner):
     return self.A_
 
 
-class ITML_Supervised(ITML):
+class ITML_Supervised(ITML, SupervisedMetricLearner):
   """Information Theoretic Metric Learning (ITML)"""
   def __init__(self, gamma=1., max_iter=1000, convergence_threshold=1e-3,
                num_labeled=np.inf, num_constraints=None, bounds=None, A0=None,

--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -19,12 +19,12 @@ from six.moves import xrange
 from sklearn.metrics import pairwise_distances
 from sklearn.utils.validation import check_array, check_X_y
 
-from .base_metric import PairsMetricLearner, SupervisedMetricLearner
+from .base_metric import BaseMetricLearner, PairsMixin, SupervisedMixin
 from .constraints import Constraints, unwrap_pairs, wrap_pairs
 from ._util import vector_norm
 
 
-class ITML(PairsMetricLearner):
+class _ITML(BaseMetricLearner):
   """Information Theoretic Metric Learning (ITML)"""
   def __init__(self, gamma=1., max_iter=1000, convergence_threshold=1e-3,
                A0=None, verbose=False):
@@ -73,7 +73,7 @@ class ITML(PairsMetricLearner):
       self.A_ = check_array(self.A0)
     return a,b,c,d
 
-  def fit(self, X_constrained, y, bounds=None):
+  def _fit(self, X_constrained, y, bounds=None):
     """Learn the ITML model.
 
     Parameters
@@ -140,7 +140,7 @@ class ITML(PairsMetricLearner):
     return self.A_
 
 
-class ITML_Supervised(ITML, SupervisedMetricLearner):
+class ITML_Supervised(_ITML, SupervisedMixin):
   """Information Theoretic Metric Learning (ITML)"""
   def __init__(self, gamma=1., max_iter=1000, convergence_threshold=1e-3,
                num_labeled=np.inf, num_constraints=None, bounds=None, A0=None,
@@ -164,7 +164,7 @@ class ITML_Supervised(ITML, SupervisedMetricLearner):
     verbose : bool, optional
         if True, prints information while learning
     """
-    ITML.__init__(self, gamma=gamma, max_iter=max_iter,
+    _ITML.__init__(self, gamma=gamma, max_iter=max_iter,
                   convergence_threshold=convergence_threshold,
                   A0=A0, verbose=verbose)
     self.num_labeled = num_labeled
@@ -196,4 +196,8 @@ class ITML_Supervised(ITML, SupervisedMetricLearner):
     pos_neg = c.positive_negative_pairs(num_constraints,
                                         random_state=random_state)
     X_constrained, y = wrap_pairs(X, pos_neg)
-    return ITML.fit(self, X_constrained, y, bounds=self.bounds)
+    return _ITML._fit(self, X_constrained, y, bounds=self.bounds)
+
+class ITML(_ITML, PairsMixin):
+
+  pass

--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -73,19 +73,19 @@ class _ITML(BaseMetricLearner):
       self.A_ = check_array(self.A0)
     return a,b,c,d
 
-  def _fit(self, X_constrained, y, bounds=None):
+  def _fit(self, X_constrained, y_constraints, bounds=None):
     """Learn the ITML model.
 
     Parameters
     ----------
     X_constrained : ConstrainedDataset
         with constraints being an array of shape [n_constraints, 2]
-    y : array-like, shape (n_constraints x 1)
+    y_constraints : array-like, shape (n_constraints x 1)
         labels of the constraints
     bounds : list (pos,neg) pairs, optional
         bounds on similarity, s.t. d(X[a],X[b]) < pos and d(X[c],X[d]) > neg
     """
-    X, constraints = unwrap_pairs(X_constrained, y)
+    X, constraints = unwrap_pairs(X_constrained, y_constraints)
     a,b,c,d = self._process_inputs(X, constraints, bounds)
     gamma = self.gamma
     num_pos = len(a)

--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -73,19 +73,19 @@ class ITML(PairsMetricLearner):
       self.A_ = check_array(self.A0)
     return a,b,c,d
 
-  def fit(self, constrained_dataset, y, bounds=None):
+  def fit(self, X_constrained, y, bounds=None):
     """Learn the ITML model.
 
     Parameters
     ----------
-    constrained_dataset : ConstrainedDataset
+    X_constrained : ConstrainedDataset
         with constraints being an array of shape [n_constraints, 2]
-    y : array-like, shape (n x 1)
+    y : array-like, shape (n_constraints x 1)
         labels of the constraints
     bounds : list (pos,neg) pairs, optional
         bounds on similarity, s.t. d(X[a],X[b]) < pos and d(X[c],X[d]) > neg
     """
-    X, constraints = unwrap_pairs(constrained_dataset, y)
+    X, constraints = unwrap_pairs(X_constrained, y)
     a,b,c,d = self._process_inputs(X, constraints, bounds)
     gamma = self.gamma
     num_pos = len(a)
@@ -195,5 +195,5 @@ class ITML_Supervised(ITML, SupervisedMetricLearner):
                                   random_state=random_state)
     pos_neg = c.positive_negative_pairs(num_constraints,
                                         random_state=random_state)
-    constrained_dataset, y = wrap_pairs(X, pos_neg)
-    return ITML.fit(self, constrained_dataset, y, bounds=self.bounds)
+    X_constrained, y = wrap_pairs(X, pos_neg)
+    return ITML.fit(self, X_constrained, y, bounds=self.bounds)

--- a/metric_learn/lfda.py
+++ b/metric_learn/lfda.py
@@ -18,10 +18,10 @@ from six.moves import xrange
 from sklearn.metrics import pairwise_distances
 from sklearn.utils.validation import check_X_y
 
-from .base_metric import BaseMetricLearner
+from .base_metric import SupervisedMetricLearner
 
 
-class LFDA(BaseMetricLearner):
+class LFDA(SupervisedMetricLearner):
   '''
   Local Fisher Discriminant Analysis for Supervised Dimensionality Reduction
   Sugiyama, ICML 2006

--- a/metric_learn/lfda.py
+++ b/metric_learn/lfda.py
@@ -18,10 +18,10 @@ from six.moves import xrange
 from sklearn.metrics import pairwise_distances
 from sklearn.utils.validation import check_X_y
 
-from .base_metric import SupervisedMetricLearner
+from .base_metric import BaseMetricLearner, SupervisedMixin
 
 
-class LFDA(SupervisedMetricLearner):
+class _LFDA(BaseMetricLearner):
   '''
   Local Fisher Discriminant Analysis for Supervised Dimensionality Reduction
   Sugiyama, ICML 2006
@@ -77,7 +77,7 @@ class LFDA(SupervisedMetricLearner):
 
     return self.X_, y, num_classes, n, d, dim, k
 
-  def fit(self, X, y):
+  def _fit(self, X, y):
     '''Fit the LFDA model.
 
     Parameters
@@ -146,3 +146,19 @@ def _eigh(a, b, dim):
   except np.linalg.LinAlgError:
     pass
   return scipy.linalg.eig(a, b)
+
+
+class LFDA(_LFDA, SupervisedMixin):
+
+  def fit(self, X, y):
+    '''Fit the LFDA model.
+
+    Parameters
+    ----------
+    X : (n, d) array-like
+        Input data.
+
+    y : (n,) array-like
+        Class labels, one per point of data.
+    '''
+    return self._fit(X, y)

--- a/metric_learn/lfda.py
+++ b/metric_learn/lfda.py
@@ -21,7 +21,7 @@ from sklearn.utils.validation import check_X_y
 from .base_metric import BaseMetricLearner, SupervisedMixin
 
 
-class _LFDA(BaseMetricLearner):
+class LFDA(BaseMetricLearner, SupervisedMixin):
   '''
   Local Fisher Discriminant Analysis for Supervised Dimensionality Reduction
   Sugiyama, ICML 2006
@@ -77,7 +77,7 @@ class _LFDA(BaseMetricLearner):
 
     return self.X_, y, num_classes, n, d, dim, k
 
-  def _fit(self, X, y):
+  def fit(self, X, y):
     '''Fit the LFDA model.
 
     Parameters
@@ -146,19 +146,3 @@ def _eigh(a, b, dim):
   except np.linalg.LinAlgError:
     pass
   return scipy.linalg.eig(a, b)
-
-
-class LFDA(_LFDA, SupervisedMixin):
-
-  def fit(self, X, y):
-    '''Fit the LFDA model.
-
-    Parameters
-    ----------
-    X : (n, d) array-like
-        Input data.
-
-    y : (n,) array-like
-        Class labels, one per point of data.
-    '''
-    return self._fit(X, y)

--- a/metric_learn/lmnn.py
+++ b/metric_learn/lmnn.py
@@ -17,11 +17,11 @@ from six.moves import xrange
 from sklearn.utils.validation import check_X_y, check_array
 from sklearn.metrics import euclidean_distances
 
-from .base_metric import BaseMetricLearner
+from .base_metric import SupervisedMetricLearner
 
 
 # commonality between LMNN implementations
-class _base_LMNN(BaseMetricLearner):
+class _base_LMNN(SupervisedMetricLearner):
   def __init__(self, k=3, min_iter=50, max_iter=1000, learn_rate=1e-7,
                regularization=0.5, convergence_tol=0.001, use_pca=True,
                verbose=False):

--- a/metric_learn/lmnn.py
+++ b/metric_learn/lmnn.py
@@ -49,7 +49,7 @@ class _base_LMNN(BaseMetricLearner):
 
 
 # slower Python version
-class _python_LMNN(_base_LMNN):
+class python_LMNN(_base_LMNN, SupervisedMixin):
 
   def _process_inputs(self, X, labels):
     self.X_ = check_array(X, dtype=float)
@@ -66,7 +66,7 @@ class _python_LMNN(_base_LMNN):
       raise ValueError('not enough class labels for specified k'
                        ' (smallest class has %d)' % required_k)
 
-  def _fit(self, X, y):
+  def fit(self, X, y):
     k = self.k
     reg = self.regularization
     learn_rate = self.learn_rate
@@ -244,9 +244,9 @@ try:
   from modshogun import LMNN as shogun_LMNN
   from modshogun import RealFeatures, MulticlassLabels
 
-  class _LMNN(_base_LMNN):
+  class LMNN(_base_LMNN, SupervisedMixin):
 
-    def _fit(self, X, y):
+    def fit(self, X, y):
       self.X_, y = check_X_y(X, y, dtype=float)
       labels = MulticlassLabels(y)
       self._lmnn = shogun_LMNN(RealFeatures(self.X_.T), labels, self.k)
@@ -262,17 +262,6 @@ try:
       return self
 
 
-  class LMNN(_LMNN, SupervisedMixin):
-
-    def fit(self, X, y):
-      return self._fit(X, y)
-
-
 except ImportError:
-
-  class python_LMNN(_python_LMNN, SupervisedMixin):
-
-    def fit(self, X, y):
-      return self._fit(X, y)
 
   LMNN = python_LMNN

--- a/metric_learn/lsml.py
+++ b/metric_learn/lsml.py
@@ -186,7 +186,5 @@ class LSML_Supervised(LSML, SupervisedMetricLearner):
                                   random_state=random_state)
     pairs = c.positive_negative_pairs(num_constraints, same_length=True,
                                       random_state=random_state)
-    X_constrained = ConstrainedDataset(X, np.hstack([pairs[i][:, None]
-                                                           for i in
-                                                           range(4)]))
+    X_constrained = ConstrainedDataset(X, np.column_stack(pairs))
     return LSML.fit(self, X_constrained, weights=self.weights)

--- a/metric_learn/lsml.py
+++ b/metric_learn/lsml.py
@@ -13,11 +13,11 @@ import scipy.linalg
 from six.moves import xrange
 from sklearn.utils.validation import check_array, check_X_y
 
-from .base_metric import BaseMetricLearner
+from .base_metric import PairsMetricLearner, SupervisedMetricLearner
 from .constraints import Constraints
 
 
-class LSML(BaseMetricLearner):
+class LSML(PairsMetricLearner):
   def __init__(self, tol=1e-3, max_iter=1000, prior=None, verbose=False):
     """Initialize LSML.
 
@@ -131,7 +131,7 @@ class LSML(BaseMetricLearner):
     return dMetric
 
 
-class LSML_Supervised(LSML):
+class LSML_Supervised(LSML, SupervisedMetricLearner):
   def __init__(self, tol=1e-3, max_iter=1000, prior=None, num_labeled=np.inf,
                num_constraints=None, weights=None, verbose=False):
     """Initialize the learner.

--- a/metric_learn/lsml.py
+++ b/metric_learn/lsml.py
@@ -13,11 +13,11 @@ import scipy.linalg
 from six.moves import xrange
 from sklearn.utils.validation import check_array, check_X_y
 
-from .base_metric import SupervisedMetricLearner, QuadrupletsMetricLearner
+from .base_metric import BaseMetricLearner, SupervisedMixin, QuadrupletsMixin
 from .constraints import Constraints, ConstrainedDataset
 
 
-class LSML(QuadrupletsMetricLearner):
+class _LSML(BaseMetricLearner):
   def __init__(self, tol=1e-3, max_iter=1000, prior=None, verbose=False):
     """Initialize LSML.
 
@@ -57,7 +57,7 @@ class LSML(QuadrupletsMetricLearner):
   def metric(self):
     return self.M_
 
-  def fit(self, X_constrained, y=None, weights=None):
+  def _fit(self, X_constrained, y=None, weights=None):
     """Learn the LSML model.
 
     Parameters
@@ -136,7 +136,7 @@ class LSML(QuadrupletsMetricLearner):
     return dMetric
 
 
-class LSML_Supervised(LSML, SupervisedMetricLearner):
+class LSML_Supervised(_LSML, SupervisedMixin):
   def __init__(self, tol=1e-3, max_iter=1000, prior=None, num_labeled=np.inf,
                num_constraints=None, weights=None, verbose=False):
     """Initialize the learner.
@@ -156,7 +156,7 @@ class LSML_Supervised(LSML, SupervisedMetricLearner):
     verbose : bool, optional
         if True, prints information while learning
     """
-    LSML.__init__(self, tol=tol, max_iter=max_iter, prior=prior,
+    _LSML.__init__(self, tol=tol, max_iter=max_iter, prior=prior,
                   verbose=verbose)
     self.num_labeled = num_labeled
     self.num_constraints = num_constraints
@@ -187,4 +187,9 @@ class LSML_Supervised(LSML, SupervisedMetricLearner):
     pairs = c.positive_negative_pairs(num_constraints, same_length=True,
                                       random_state=random_state)
     X_constrained = ConstrainedDataset(X, np.column_stack(pairs))
-    return LSML.fit(self, X_constrained, weights=self.weights)
+    return _LSML._fit(self, X_constrained, weights=self.weights)
+
+
+class LSML(_LSML, QuadrupletsMixin):
+
+  pass

--- a/metric_learn/lsml.py
+++ b/metric_learn/lsml.py
@@ -57,12 +57,12 @@ class LSML(QuadrupletsMetricLearner):
   def metric(self):
     return self.M_
 
-  def fit(self, constrained_dataset, y=None, weights=None):
+  def fit(self, X_constrained, y=None, weights=None):
     """Learn the LSML model.
 
     Parameters
     ----------
-    constrained_dataset : ConstrainedDataset
+    X_constrained : ConstrainedDataset
         with constraints being an array of shape [n_constraints, 4]. It
         should be the concatenation of 4 column vectors a, b, c and d,
         such that: ``d(X[a[i]],X[b[i]]) < d(X[c[i]],X[d[i]])`` for every
@@ -72,8 +72,8 @@ class LSML(QuadrupletsMetricLearner):
     weights : (m,) array of floats, optional
         scale factor for each constraint
     """
-    X = constrained_dataset.X
-    constraints = [constrained_dataset.c[:, i].ravel() for i in range(4)]
+    X = X_constrained.X
+    constraints = [X_constrained.c[:, i].ravel() for i in range(4)]
     self._prepare_inputs(X, constraints, weights)
     step_sizes = np.logspace(-10, 0, 10)
     # Keep track of the best step size and the loss at that step.
@@ -186,7 +186,7 @@ class LSML_Supervised(LSML, SupervisedMetricLearner):
                                   random_state=random_state)
     pairs = c.positive_negative_pairs(num_constraints, same_length=True,
                                       random_state=random_state)
-    constrained_dataset = ConstrainedDataset(X, np.hstack([pairs[i][:, None]
+    X_constrained = ConstrainedDataset(X, np.hstack([pairs[i][:, None]
                                                            for i in
                                                            range(4)]))
-    return LSML.fit(self, constrained_dataset, weights=self.weights)
+    return LSML.fit(self, X_constrained, weights=self.weights)

--- a/metric_learn/lsml.py
+++ b/metric_learn/lsml.py
@@ -57,7 +57,7 @@ class _LSML(BaseMetricLearner):
   def metric(self):
     return self.M_
 
-  def _fit(self, X_constrained, y=None, weights=None):
+  def _fit(self, X_constrained, weights=None):
     """Learn the LSML model.
 
     Parameters

--- a/metric_learn/mlkr.py
+++ b/metric_learn/mlkr.py
@@ -18,7 +18,7 @@ from .base_metric import BaseMetricLearner, SupervisedMixin
 EPS = np.finfo(float).eps
 
 
-class _MLKR(BaseMetricLearner):
+class MLKR(BaseMetricLearner, SupervisedMixin):
   """Metric Learning for Kernel Regression (MLKR)"""
   def __init__(self, num_dims=None, A0=None, epsilon=0.01, alpha=0.0001,
                max_iter=1000):
@@ -68,7 +68,7 @@ class _MLKR(BaseMetricLearner):
               m, d, A.shape))
       return self.X_, y, A
 
-  def _fit(self, X, y):
+  def fit(self, X, y):
       """
       Fit MLKR model
 
@@ -111,16 +111,3 @@ def _loss(flatA, X, y, dX):
   grad = 2 * A.dot(M)
   return cost, grad.ravel()
 
-
-class MLKR(_MLKR, SupervisedMixin):
-
-    def fit(self, X, y):
-        """
-        Fit MLKR model
-
-        Parameters
-        ----------
-        X : (n x d) array of samples
-        y : (n) data labels
-        """
-        return self._fit(X, y)

--- a/metric_learn/mlkr.py
+++ b/metric_learn/mlkr.py
@@ -13,12 +13,12 @@ from scipy.spatial.distance import pdist, squareform
 from sklearn.decomposition import PCA
 from sklearn.utils.validation import check_X_y
 
-from .base_metric import BaseMetricLearner
+from .base_metric import SupervisedMetricLearner
 
 EPS = np.finfo(float).eps
 
 
-class MLKR(BaseMetricLearner):
+class MLKR(SupervisedMetricLearner):
   """Metric Learning for Kernel Regression (MLKR)"""
   def __init__(self, num_dims=None, A0=None, epsilon=0.01, alpha=0.0001,
                max_iter=1000):

--- a/metric_learn/mlkr.py
+++ b/metric_learn/mlkr.py
@@ -13,12 +13,12 @@ from scipy.spatial.distance import pdist, squareform
 from sklearn.decomposition import PCA
 from sklearn.utils.validation import check_X_y
 
-from .base_metric import SupervisedMetricLearner
+from .base_metric import BaseMetricLearner, SupervisedMixin
 
 EPS = np.finfo(float).eps
 
 
-class MLKR(SupervisedMetricLearner):
+class _MLKR(BaseMetricLearner):
   """Metric Learning for Kernel Regression (MLKR)"""
   def __init__(self, num_dims=None, A0=None, epsilon=0.01, alpha=0.0001,
                max_iter=1000):
@@ -68,7 +68,7 @@ class MLKR(SupervisedMetricLearner):
               m, d, A.shape))
       return self.X_, y, A
 
-  def fit(self, X, y):
+  def _fit(self, X, y):
       """
       Fit MLKR model
 
@@ -110,3 +110,17 @@ def _loss(flatA, X, y, dX):
   M = (dX.T * W.ravel()).dot(dX)
   grad = 2 * A.dot(M)
   return cost, grad.ravel()
+
+
+class MLKR(_MLKR, SupervisedMixin):
+
+    def fit(self, X, y):
+        """
+        Fit MLKR model
+
+        Parameters
+        ----------
+        X : (n x d) array of samples
+        y : (n) data labels
+        """
+        return self._fit(X, y)

--- a/metric_learn/mmc.py
+++ b/metric_learn/mmc.py
@@ -58,17 +58,17 @@ class _MMC(BaseMetricLearner):
     self.diagonal_c = diagonal_c
     self.verbose = verbose
 
-  def _fit(self, X_constrained, y):
+  def _fit(self, X_constrained, y_constraints):
     """Learn the MMC model.
 
     Parameters
     ----------
     X_constrained : ConstrainedDataset
         with constraints being an array of shape [n_constraints, 2]
-    y : array-like, shape (n_constraints x 1)
+    y_constraints : array-like, shape (n_constraints x 1)
         labels of the constraints
     """
-    X, constraints = unwrap_pairs(X_constrained, y)
+    X, constraints = unwrap_pairs(X_constrained, y_constraints)
     constraints = self._process_inputs(X, constraints)
     if self.diagonal:
       return self._fit_diag(X, constraints)

--- a/metric_learn/mmc.py
+++ b/metric_learn/mmc.py
@@ -59,17 +59,17 @@ class MMC(PairsMetricLearner):
     self.diagonal_c = diagonal_c
     self.verbose = verbose
 
-  def fit(self, constrained_dataset, y):
+  def fit(self, X_constrained, y):
     """Learn the MMC model.
 
     Parameters
     ----------
-    constrained_dataset : ConstrainedDataset
+    X_constrained : ConstrainedDataset
         with constraints being an array of shape [n_constraints, 2]
-    y : array-like, shape (n x 1)
+    y : array-like, shape (n_constraints x 1)
         labels of the constraints
     """
-    X, constraints = unwrap_pairs(constrained_dataset, y)
+    X, constraints = unwrap_pairs(X_constrained, y)
     constraints = self._process_inputs(X, constraints)
     if self.diagonal:
       return self._fit_diag(X, constraints)
@@ -438,5 +438,5 @@ class MMC_Supervised(MMC, SupervisedMetricLearner):
                                   random_state=random_state)
     pos_neg = c.positive_negative_pairs(num_constraints,
                                         random_state=random_state)
-    constrained_dataset, y = wrap_pairs(X, pos_neg)
-    return MMC.fit(self, constrained_dataset, y)
+    X_constrained, y = wrap_pairs(X, pos_neg)
+    return MMC.fit(self, X_constrained, y)

--- a/metric_learn/mmc.py
+++ b/metric_learn/mmc.py
@@ -21,14 +21,14 @@ import numpy as np
 from six.moves import xrange
 from sklearn.utils.validation import check_array, check_X_y
 
-from .base_metric import PairsMetricLearner, SupervisedMetricLearner
+from .base_metric import PairsMixin, BaseMetricLearner, SupervisedMixin
 from .constraints import (Constraints, ConstrainedDataset,
                           unwrap_pairs, wrap_pairs)
 from ._util import vector_norm
 
 
 
-class MMC(PairsMetricLearner):
+class _MMC(BaseMetricLearner):
   """Mahalanobis Metric for Clustering (MMC)"""
   def __init__(self, max_iter=100, max_proj=10000, convergence_threshold=1e-3,
                A0=None, diagonal=False, diagonal_c=1.0, verbose=False):
@@ -58,7 +58,7 @@ class MMC(PairsMetricLearner):
     self.diagonal_c = diagonal_c
     self.verbose = verbose
 
-  def fit(self, X_constrained, y):
+  def _fit(self, X_constrained, y):
     """Learn the MMC model.
 
     Parameters
@@ -380,7 +380,7 @@ class MMC(PairsMetricLearner):
       return V.T * np.sqrt(np.maximum(0, w[:,None]))
 
 
-class MMC_Supervised(MMC, SupervisedMetricLearner):
+class MMC_Supervised(_MMC, SupervisedMixin):
   """Mahalanobis Metric for Clustering (MMC)"""
   def __init__(self, max_iter=100, max_proj=10000, convergence_threshold=1e-6,
                num_labeled=np.inf, num_constraints=None,
@@ -408,7 +408,7 @@ class MMC_Supervised(MMC, SupervisedMetricLearner):
     verbose : bool, optional
         if True, prints information while learning
     """
-    MMC.__init__(self, max_iter=max_iter, max_proj=max_proj,
+    _MMC.__init__(self, max_iter=max_iter, max_proj=max_proj,
                  convergence_threshold=convergence_threshold,
                  A0=A0, diagonal=diagonal, diagonal_c=diagonal_c,
                  verbose=verbose)
@@ -438,4 +438,8 @@ class MMC_Supervised(MMC, SupervisedMetricLearner):
     pos_neg = c.positive_negative_pairs(num_constraints,
                                         random_state=random_state)
     X_constrained, y = wrap_pairs(X, pos_neg)
-    return MMC.fit(self, X_constrained, y)
+    return _MMC._fit(self, X_constrained, y)
+
+class MMC(_MMC, PairsMixin):
+
+  pass

--- a/metric_learn/mmc.py
+++ b/metric_learn/mmc.py
@@ -22,13 +22,13 @@ from six.moves import xrange
 from sklearn.metrics import pairwise_distances
 from sklearn.utils.validation import check_array, check_X_y
 
-from .base_metric import BaseMetricLearner
+from .base_metric import PairsMetricLearner, SupervisedMetricLearner
 from .constraints import Constraints
 from ._util import vector_norm
 
 
 
-class MMC(BaseMetricLearner):
+class MMC(PairsMetricLearner):
   """Mahalanobis Metric for Clustering (MMC)"""
   def __init__(self, max_iter=100, max_proj=10000, convergence_threshold=1e-3,
                A0=None, diagonal=False, diagonal_c=1.0, verbose=False):
@@ -380,7 +380,7 @@ class MMC(BaseMetricLearner):
       return V.T * np.sqrt(np.maximum(0, w[:,None]))
 
 
-class MMC_Supervised(MMC):
+class MMC_Supervised(MMC, SupervisedMetricLearner):
   """Mahalanobis Metric for Clustering (MMC)"""
   def __init__(self, max_iter=100, max_proj=10000, convergence_threshold=1e-6,
                num_labeled=np.inf, num_constraints=None,

--- a/metric_learn/mmc.py
+++ b/metric_learn/mmc.py
@@ -19,12 +19,11 @@ Adapted from Matlab code at http://www.cs.cmu.edu/%7Eepxing/papers/Old_papers/co
 from __future__ import print_function, absolute_import, division
 import numpy as np
 from six.moves import xrange
-from sklearn.metrics import pairwise_distances
 from sklearn.utils.validation import check_array, check_X_y
 
 from .base_metric import PairsMetricLearner, SupervisedMetricLearner
-from .constraints import Constraints, ConstrainedDataset, unwrap_pairs, \
-  wrap_pairs
+from .constraints import (Constraints, ConstrainedDataset,
+                          unwrap_pairs, wrap_pairs)
 from ._util import vector_norm
 
 

--- a/metric_learn/nca.py
+++ b/metric_learn/nca.py
@@ -8,12 +8,12 @@ import numpy as np
 from six.moves import xrange
 from sklearn.utils.validation import check_X_y
 
-from .base_metric import SupervisedMetricLearner
+from .base_metric import BaseMetricLearner, SupervisedMixin
 
 EPS = np.finfo(float).eps
 
 
-class NCA(SupervisedMetricLearner):
+class _NCA(BaseMetricLearner):
   def __init__(self, num_dims=None, max_iter=100, learning_rate=0.01):
     self.num_dims = num_dims
     self.max_iter = max_iter
@@ -22,7 +22,7 @@ class NCA(SupervisedMetricLearner):
   def transformer(self):
     return self.A_
 
-  def fit(self, X, y):
+  def _fit(self, X, y):
     """
     X: data matrix, (n x d)
     y: scalar labels, (n)
@@ -57,3 +57,12 @@ class NCA(SupervisedMetricLearner):
     self.A_ = A
     self.n_iter_ = it
     return self
+
+class NCA(_NCA, SupervisedMixin):
+
+  def fit(self, X, y):
+    """
+    X: data matrix, (n x d)
+    y: scalar labels, (n)
+    """
+    return self._fit(X, y)

--- a/metric_learn/nca.py
+++ b/metric_learn/nca.py
@@ -8,12 +8,12 @@ import numpy as np
 from six.moves import xrange
 from sklearn.utils.validation import check_X_y
 
-from .base_metric import BaseMetricLearner
+from .base_metric import SupervisedMetricLearner
 
 EPS = np.finfo(float).eps
 
 
-class NCA(BaseMetricLearner):
+class NCA(SupervisedMetricLearner):
   def __init__(self, num_dims=None, max_iter=100, learning_rate=0.01):
     self.num_dims = num_dims
     self.max_iter = max_iter

--- a/metric_learn/nca.py
+++ b/metric_learn/nca.py
@@ -13,7 +13,7 @@ from .base_metric import BaseMetricLearner, SupervisedMixin
 EPS = np.finfo(float).eps
 
 
-class _NCA(BaseMetricLearner):
+class NCA(BaseMetricLearner, SupervisedMixin):
   def __init__(self, num_dims=None, max_iter=100, learning_rate=0.01):
     self.num_dims = num_dims
     self.max_iter = max_iter
@@ -22,7 +22,7 @@ class _NCA(BaseMetricLearner):
   def transformer(self):
     return self.A_
 
-  def _fit(self, X, y):
+  def fit(self, X, y):
     """
     X: data matrix, (n x d)
     y: scalar labels, (n)
@@ -57,12 +57,3 @@ class _NCA(BaseMetricLearner):
     self.A_ = A
     self.n_iter_ = it
     return self
-
-class NCA(_NCA, SupervisedMixin):
-
-  def fit(self, X, y):
-    """
-    X: data matrix, (n x d)
-    y: scalar labels, (n)
-    """
-    return self._fit(X, y)

--- a/metric_learn/rca.py
+++ b/metric_learn/rca.py
@@ -35,7 +35,7 @@ def _chunk_mean_centering(data, chunks):
   return chunk_mask, chunk_data
 
 
-class _RCA(BaseMetricLearner):
+class RCA(BaseMetricLearner, SupervisedMixin):
   """Relevant Components Analysis (RCA)"""
   def __init__(self, num_dims=None, pca_comps=None):
     """Initialize the learner.
@@ -92,7 +92,7 @@ class _RCA(BaseMetricLearner):
       dim = self.num_dims
     return dim
 
-  def _fit(self, data, chunks):
+  def fit(self, data, chunks):
     """Learn the RCA model.
 
     Parameters
@@ -135,7 +135,7 @@ def _inv_sqrtm(x):
   return (vecs / np.sqrt(vals)).dot(vecs.T)
 
 
-class RCA_Supervised(_RCA, SupervisedMixin):
+class RCA_Supervised(RCA):
   def __init__(self, num_dims=None, pca_comps=None, num_chunks=100,
                chunk_size=2):
     """Initialize the learner.
@@ -147,7 +147,7 @@ class RCA_Supervised(_RCA, SupervisedMixin):
     num_chunks: int, optional
     chunk_size: int, optional
     """
-    _RCA.__init__(self, num_dims=num_dims, pca_comps=pca_comps)
+    RCA.__init__(self, num_dims=num_dims, pca_comps=pca_comps)
     self.num_chunks = num_chunks
     self.chunk_size = chunk_size
 
@@ -165,8 +165,4 @@ class RCA_Supervised(_RCA, SupervisedMixin):
     chunks = Constraints(y).chunks(num_chunks=self.num_chunks,
                                    chunk_size=self.chunk_size,
                                    random_state=random_state)
-    return _RCA._fit(self, X, chunks)
-
-class RCA(_RCA, PairsMixin):
-
-  pass
+    return RCA.fit(self, X, chunks)

--- a/metric_learn/rca.py
+++ b/metric_learn/rca.py
@@ -18,7 +18,7 @@ from six.moves import xrange
 from sklearn import decomposition
 from sklearn.utils.validation import check_array
 
-from .base_metric import BaseMetricLearner
+from .base_metric import SupervisedMetricLearner
 from .constraints import Constraints
 
 
@@ -35,7 +35,7 @@ def _chunk_mean_centering(data, chunks):
   return chunk_mask, chunk_data
 
 
-class RCA(BaseMetricLearner):
+class RCA(SupervisedMetricLearner):
   """Relevant Components Analysis (RCA)"""
   def __init__(self, num_dims=None, pca_comps=None):
     """Initialize the learner.

--- a/metric_learn/rca.py
+++ b/metric_learn/rca.py
@@ -18,7 +18,7 @@ from six.moves import xrange
 from sklearn import decomposition
 from sklearn.utils.validation import check_array
 
-from .base_metric import SupervisedMetricLearner
+from .base_metric import BaseMetricLearner, PairsMixin, SupervisedMixin
 from .constraints import Constraints
 
 
@@ -35,7 +35,7 @@ def _chunk_mean_centering(data, chunks):
   return chunk_mask, chunk_data
 
 
-class RCA(SupervisedMetricLearner):
+class _RCA(BaseMetricLearner):
   """Relevant Components Analysis (RCA)"""
   def __init__(self, num_dims=None, pca_comps=None):
     """Initialize the learner.
@@ -92,7 +92,7 @@ class RCA(SupervisedMetricLearner):
       dim = self.num_dims
     return dim
 
-  def fit(self, data, chunks):
+  def _fit(self, data, chunks):
     """Learn the RCA model.
 
     Parameters
@@ -135,7 +135,7 @@ def _inv_sqrtm(x):
   return (vecs / np.sqrt(vals)).dot(vecs.T)
 
 
-class RCA_Supervised(RCA):
+class RCA_Supervised(_RCA, SupervisedMixin):
   def __init__(self, num_dims=None, pca_comps=None, num_chunks=100,
                chunk_size=2):
     """Initialize the learner.
@@ -147,7 +147,7 @@ class RCA_Supervised(RCA):
     num_chunks: int, optional
     chunk_size: int, optional
     """
-    RCA.__init__(self, num_dims=num_dims, pca_comps=pca_comps)
+    _RCA.__init__(self, num_dims=num_dims, pca_comps=pca_comps)
     self.num_chunks = num_chunks
     self.chunk_size = chunk_size
 
@@ -165,4 +165,8 @@ class RCA_Supervised(RCA):
     chunks = Constraints(y).chunks(num_chunks=self.num_chunks,
                                    chunk_size=self.chunk_size,
                                    random_state=random_state)
-    return RCA.fit(self, X, chunks)
+    return _RCA._fit(self, X, chunks)
+
+class RCA(_RCA, PairsMixin):
+
+  pass

--- a/metric_learn/sdml.py
+++ b/metric_learn/sdml.py
@@ -56,14 +56,14 @@ class _SDML(BaseMetricLearner):
   def metric(self):
     return self.M_
 
-  def _fit(self, X_constrained, y):
+  def _fit(self, X_constrained, y_constraints):
     """Learn the SDML model.
 
     Parameters
     ----------
     X_constrained : ConstrainedDataset
         with constraints being an array of shape [n_constraints, 2]
-    y : array-like, shape (n_constraints x 1)
+    y_constraints : array-like, shape (n_constraints x 1)
         labels of the constraints
 
     Returns
@@ -71,7 +71,7 @@ class _SDML(BaseMetricLearner):
     self : object
         Returns the instance.
     """
-    X, W = unwrap_to_graph(X_constrained, y)
+    X, W = unwrap_to_graph(X_constrained, y_constraints)
     loss_matrix = self._prepare_inputs(X, W)
     P = self.M_ + self.balance_param * loss_matrix
     emp_cov = pinvh(P)

--- a/metric_learn/sdml.py
+++ b/metric_learn/sdml.py
@@ -56,14 +56,14 @@ class SDML(PairsMetricLearner):
   def metric(self):
     return self.M_
 
-  def fit(self, constrained_dataset, y):
+  def fit(self, X_constrained, y):
     """Learn the SDML model.
 
     Parameters
     ----------
-    constrained_dataset : ConstrainedDataset
+    X_constrained : ConstrainedDataset
         with constraints being an array of shape [n_constraints, 2]
-    y : array-like, shape (n x 1)
+    y : array-like, shape (n_constraints x 1)
         labels of the constraints
 
     Returns
@@ -71,7 +71,7 @@ class SDML(PairsMetricLearner):
     self : object
         Returns the instance.
     """
-    X, W = unwrap_to_graph(constrained_dataset, y)
+    X, W = unwrap_to_graph(X_constrained, y)
     loss_matrix = self._prepare_inputs(X, W)
     P = self.M_ + self.balance_param * loss_matrix
     emp_cov = pinvh(P)
@@ -134,5 +134,5 @@ class SDML_Supervised(SDML, SupervisedMetricLearner):
                                   random_state=random_state)
     pos_neg = c.positive_negative_pairs(num_constraints,
                                               random_state=random_state)
-    constrained_dataset, y = wrap_pairs(X, pos_neg)
-    return SDML.fit(self, constrained_dataset, y)
+    X_constrained, y = wrap_pairs(X, pos_neg)
+    return SDML.fit(self, X_constrained, y)

--- a/metric_learn/sdml.py
+++ b/metric_learn/sdml.py
@@ -15,11 +15,11 @@ from sklearn.covariance import graph_lasso
 from sklearn.utils.extmath import pinvh
 from sklearn.utils.validation import check_array
 
-from .base_metric import PairsMetricLearner, SupervisedMetricLearner
+from .base_metric import PairsMixin, SupervisedMixin, BaseMetricLearner
 from .constraints import Constraints, wrap_pairs, unwrap_to_graph
 
 
-class SDML(PairsMetricLearner):
+class _SDML(BaseMetricLearner):
   def __init__(self, balance_param=0.5, sparsity_param=0.01, use_cov=True,
                verbose=False):
     """
@@ -56,7 +56,7 @@ class SDML(PairsMetricLearner):
   def metric(self):
     return self.M_
 
-  def fit(self, X_constrained, y):
+  def _fit(self, X_constrained, y):
     """Learn the SDML model.
 
     Parameters
@@ -81,7 +81,7 @@ class SDML(PairsMetricLearner):
     return self
 
 
-class SDML_Supervised(SDML, SupervisedMetricLearner):
+class SDML_Supervised(_SDML, SupervisedMixin):
   def __init__(self, balance_param=0.5, sparsity_param=0.01, use_cov=True,
                num_labeled=np.inf, num_constraints=None, verbose=False):
     """
@@ -100,7 +100,7 @@ class SDML_Supervised(SDML, SupervisedMetricLearner):
     verbose : bool, optional
         if True, prints information while learning
     """
-    SDML.__init__(self, balance_param=balance_param,
+    _SDML.__init__(self, balance_param=balance_param,
                   sparsity_param=sparsity_param, use_cov=use_cov,
                   verbose=verbose)
     self.num_labeled = num_labeled
@@ -135,4 +135,8 @@ class SDML_Supervised(SDML, SupervisedMetricLearner):
     pos_neg = c.positive_negative_pairs(num_constraints,
                                               random_state=random_state)
     X_constrained, y = wrap_pairs(X, pos_neg)
-    return SDML.fit(self, X_constrained, y)
+    return _SDML._fit(self, X_constrained, y)
+
+class SDML(_SDML, PairsMixin):
+
+  pass

--- a/metric_learn/sdml.py
+++ b/metric_learn/sdml.py
@@ -15,11 +15,11 @@ from sklearn.covariance import graph_lasso
 from sklearn.utils.extmath import pinvh
 from sklearn.utils.validation import check_array
 
-from .base_metric import BaseMetricLearner
+from .base_metric import PairsMetricLearner, SupervisedMetricLearner
 from .constraints import Constraints
 
 
-class SDML(BaseMetricLearner):
+class SDML(PairsMetricLearner):
   def __init__(self, balance_param=0.5, sparsity_param=0.01, use_cov=True,
                verbose=False):
     """
@@ -80,7 +80,7 @@ class SDML(BaseMetricLearner):
     return self
 
 
-class SDML_Supervised(SDML):
+class SDML_Supervised(SDML, SupervisedMetricLearner):
   def __init__(self, balance_param=0.5, sparsity_param=0.01, use_cov=True,
                num_labeled=np.inf, num_constraints=None, verbose=False):
     """

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -66,7 +66,7 @@ class TestLMNN(MetricTestCase):
     # Test both impls, if available.
     for LMNN_cls in set((LMNN, python_LMNN)):
       lmnn = LMNN_cls(k=5, learn_rate=1e-6, verbose=False)
-      lmnn._fit(self.iris_points, self.iris_labels)
+      lmnn.fit(self.iris_points, self.iris_labels)
 
       csep = class_separation(lmnn.transform(), self.iris_labels)
       self.assertLess(csep, 0.25)

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -7,10 +7,10 @@ from sklearn.datasets import load_iris
 from numpy.testing import assert_array_almost_equal
 
 from metric_learn import (
-    LMNN, NCA, LFDA, Covariance, MLKR, MMC,
+    NCA, LFDA, Covariance, MLKR, MMC,
     LSML_Supervised, ITML_Supervised, SDML_Supervised, RCA_Supervised, MMC_Supervised)
 # Import this specially for testing.
-from metric_learn.lmnn import python_LMNN
+from metric_learn.lmnn import python_LMNN, LMNN
 
 
 def class_separation(X, labels):
@@ -66,7 +66,7 @@ class TestLMNN(MetricTestCase):
     # Test both impls, if available.
     for LMNN_cls in set((LMNN, python_LMNN)):
       lmnn = LMNN_cls(k=5, learn_rate=1e-6, verbose=False)
-      lmnn.fit(self.iris_points, self.iris_labels)
+      lmnn._fit(self.iris_points, self.iris_labels)
 
       csep = class_separation(lmnn.transform(), self.iris_labels)
       self.assertLess(csep, 0.25)

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -1,5 +1,6 @@
 import unittest
 import numpy as np
+from metric_learn.constraints import wrap_pairs
 from six.moves import xrange
 from sklearn.metrics import pairwise_distances
 from sklearn.datasets import load_iris
@@ -160,7 +161,7 @@ class TestMMC(MetricTestCase):
 
     # Full metric
     mmc = MMC(convergence_threshold=0.01)
-    mmc.fit(self.iris_points, [a,b,c,d])
+    mmc.fit(*wrap_pairs(self.iris_points, [a,b,c,d]))
     expected = [[+0.00046504, +0.00083371, -0.00111959, -0.00165265],
                 [+0.00083371, +0.00149466, -0.00200719, -0.00296284],
                 [-0.00111959, -0.00200719, +0.00269546, +0.00397881],
@@ -169,7 +170,7 @@ class TestMMC(MetricTestCase):
 
     # Diagonal metric
     mmc = MMC(diagonal=True)
-    mmc.fit(self.iris_points, [a,b,c,d])
+    mmc.fit(*wrap_pairs(self.iris_points, [a,b,c,d]))
     expected = [0, 0, 1.21045968, 1.22552608]
     assert_array_almost_equal(np.diag(expected), mmc.metric(), decimal=6)
     

--- a/test/test_base_metric.py
+++ b/test/test_base_metric.py
@@ -9,10 +9,10 @@ class TestStringRepr(unittest.TestCase):
 
   def test_lmnn(self):
     self.assertRegexpMatches(
-        str(metric_learn.LMNN()),
-        r"(python_)?LMNN\(convergence_tol=0.001, k=3, learn_rate=1e-07, "
-        r"max_iter=1000,\n      min_iter=50, regularization=0.5, "
-        r"use_pca=True, verbose=False\)")
+      str(metric_learn.LMNN()),
+      r"^(python_)?LMNN\(convergence_tol=0.001, k=3, learn_rate=1e-07, "
+      r"max_iter=1000,(\n     )? min_iter=50,(\n  )? regularization=0.5, "
+      r"use_pca=True, verbose=False\)$")
 
   def test_nca(self):
     self.assertEqual(str(metric_learn.NCA()),

--- a/test/test_constrained_dataset.py
+++ b/test/test_constrained_dataset.py
@@ -23,9 +23,12 @@ class TestConstrainedDataset(unittest.TestCase):
         np.testing.assert_array_equal(cd[idx].toarray(), X[c[idx]])
         np.testing.assert_array_equal(cd[idx].toarray(), X[c][idx])
 
-    def test_inputs(self):
-        # test the allowed and forbidden ways to create a ConstrainedDataset
+    def test_allowed_inputs(self):
+        # test the allowed ways to create a ConstrainedDataset
         ConstrainedDataset(X, c)
+
+    def test_invalid_inputs(self):
+        # test the invalid ways to create a ConstrainedDataset
         two_points = [[1, 2], [3, 5]]
         out_of_range_constraints = [[1, 2], [0, 1]]
         msg = "ConstrainedDataset cannot be created: the length of " \

--- a/test/test_constrained_dataset.py
+++ b/test/test_constrained_dataset.py
@@ -9,7 +9,7 @@ from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.mocking import MockDataFrame
 
 
-class _BaseTestConstrainedDataset(unittest.TestCase):
+class _BaseTestConstrainedDataset(object):
 
     def setUp(self):
         self.num_points = 20
@@ -97,7 +97,8 @@ class _BaseTestConstrainedDataset(unittest.TestCase):
                         self.check_indexing(test_idx)
 
 
-class TestDenseConstrainedDataset(_BaseTestConstrainedDataset):
+class TestDenseConstrainedDataset(_BaseTestConstrainedDataset,
+                                  unittest.TestCase):
 
     def setUp(self):
         super(TestDenseConstrainedDataset, self).setUp()
@@ -116,7 +117,8 @@ class TestDenseConstrainedDataset(_BaseTestConstrainedDataset):
                 X_constrained = ConstrainedDataset(X, c)
 
 
-class TestSparseConstrainedDataset(_BaseTestConstrainedDataset):
+class TestSparseConstrainedDataset(_BaseTestConstrainedDataset,
+                                   unittest.TestCase):
 
     def setUp(self):
         super(TestSparseConstrainedDataset, self).setUp()

--- a/test/test_constrained_dataset.py
+++ b/test/test_constrained_dataset.py
@@ -65,6 +65,9 @@ class TestConstrainedDataset(unittest.TestCase):
         self.assertEqual(X_constrained.shape, (c.shape[0], X.shape[1]))
         self.assertEqual(X_constrained[0, 0].shape, (0, X.shape[1]))
 
+    def test_len(self):
+        self.assertEqual(len(X_constrained),c.shape[0])
+
     def test_toarray(self):
         assert_array_equal(X_constrained.toarray(), X_constrained.X[c])
 

--- a/test/test_constrained_dataset.py
+++ b/test/test_constrained_dataset.py
@@ -62,8 +62,9 @@ class TestConstrainedDataset(unittest.TestCase):
         self.assertEqual(str(X_constrained), str(X[c]))
 
     def test_shape(self):
-        self.assertEqual(X_constrained.shape, (c.shape[0], X.shape[1]))
-        self.assertEqual(X_constrained[0, 0].shape, (0, X.shape[1]))
+        self.assertEqual(X_constrained.shape, (c.shape[0], c.shape[1],
+                                               X.shape[1]))
+        self.assertEqual(X_constrained[0, 0].shape, (0, 0, X.shape[1]))
 
     def test_len(self):
         self.assertEqual(len(X_constrained),c.shape[0])

--- a/test/test_constrained_dataset.py
+++ b/test/test_constrained_dataset.py
@@ -3,17 +3,19 @@ import numpy as np
 from metric_learn.constraints import ConstrainedDataset
 from numpy.testing import assert_array_equal
 from sklearn.model_selection import StratifiedKFold, KFold
+from sklearn.utils import check_random_state
 from sklearn.utils.testing import assert_raise_message
 
 num_points = 20
 num_features = 5
 num_constraints = 15
+RNG = check_random_state(0)
 
-X = np.random.randn(num_points, num_features)
-c = np.random.randint(0, num_points, (num_constraints, 2))
+X = RNG.randn(num_points, num_features)
+c = RNG.randint(0, num_points, (num_constraints, 2))
 X_constrained = ConstrainedDataset(X, c)
-y = np.random.randint(0, 2, num_constraints)
-group = np.random.randint(0, 3, num_constraints)
+y = RNG.randint(0, 2, num_constraints)
+group = RNG.randint(0, 3, num_constraints)
 
 class TestConstrainedDataset(unittest.TestCase):
 
@@ -40,11 +42,11 @@ class TestConstrainedDataset(unittest.TestCase):
 
     def test_getitem(self):
         # test different types of slicing
-        i = np.random.randint(1, num_constraints - 1)
-        begin = np.random.randint(1, num_constraints - 1)
-        end = np.random.randint(begin + 1, num_constraints)
-        fancy_index = np.random.randint(0, num_constraints, 20)
-        binary_index = np.random.randint(0, 2, num_constraints)
+        i = RNG.randint(1, num_constraints - 1)
+        begin = RNG.randint(1, num_constraints - 1)
+        end = RNG.randint(begin + 1, num_constraints)
+        fancy_index = RNG.randint(0, num_constraints, 20)
+        binary_index = RNG.randint(0, 2, num_constraints)
         boolean_index = binary_index.astype(bool)
         items = [0, num_constraints - 1, i, slice(i), slice(0, begin),
                  slice(begin, end), slice(end, num_constraints),

--- a/test/test_constrained_dataset.py
+++ b/test/test_constrained_dataset.py
@@ -5,23 +5,24 @@ from numpy.testing import assert_array_equal
 from sklearn.model_selection import StratifiedKFold, KFold
 from sklearn.utils.testing import assert_raise_message
 
-X = np.random.randn(20, 5)
-c = np.random.randint(0, X.shape[0], (15, 2))
-cd = ConstrainedDataset(X, c)
-y = np.random.randint(0, 2, c.shape[0])
-group = np.random.randint(0, 3, c.shape[0])
+num_points = 20
+num_features = 5
+num_constraints = 15
 
-c_shape = c.shape[0]
-
+X = np.random.randn(num_points, num_features)
+c = np.random.randint(0, num_points, (num_constraints, 2))
+X_constrained = ConstrainedDataset(X, c)
+y = np.random.randint(0, 2, num_constraints)
+group = np.random.randint(0, 3, num_constraints)
 
 class TestConstrainedDataset(unittest.TestCase):
 
     @staticmethod
     def check_indexing(idx):
         # checks that an indexing returns the data we expect
-        np.testing.assert_array_equal(cd[idx].c, c[idx])
-        np.testing.assert_array_equal(cd[idx].toarray(), X[c[idx]])
-        np.testing.assert_array_equal(cd[idx].toarray(), X[c][idx])
+        np.testing.assert_array_equal(X_constrained[idx].c, c[idx])
+        np.testing.assert_array_equal(X_constrained[idx].toarray(), X[c[idx]])
+        np.testing.assert_array_equal(X_constrained[idx].toarray(), X[c][idx])
 
     def test_allowed_inputs(self):
         # test the allowed ways to create a ConstrainedDataset
@@ -52,17 +53,17 @@ class TestConstrainedDataset(unittest.TestCase):
             self.check_indexing(item)
 
     def test_repr(self):
-        self.assertEqual(repr(cd), repr(X[c]))
+        self.assertEqual(repr(X_constrained), repr(X[c]))
 
     def test_str(self):
-        self.assertEqual(str(cd), str(X[c]))
+        self.assertEqual(str(X_constrained), str(X[c]))
 
     def test_shape(self):
-        self.assertEqual(cd.shape, (c.shape[0], X.shape[1]))
-        self.assertEqual(cd[0, 0].shape, (0, X.shape[1]))
+        self.assertEqual(X_constrained.shape, (c.shape[0], X.shape[1]))
+        self.assertEqual(X_constrained[0, 0].shape, (0, X.shape[1]))
 
     def test_toarray(self):
-        assert_array_equal(cd.toarray(), cd.X[c])
+        assert_array_equal(X_constrained.toarray(), X_constrained.X[c])
 
     def test_folding(self):
         # test that ConstrainedDataset is compatible with scikit-learn folding
@@ -71,7 +72,8 @@ class TestConstrainedDataset(unittest.TestCase):
         for alg in [KFold, StratifiedKFold]:
             for shuffle_i in shuffle_list:
                 for group_i in groups_list:
-                    for train_idx, test_idx in alg(
-                            shuffle=shuffle_i).split(cd, y, group_i):
+                    for train_idx, test_idx \
+                            in alg(shuffle=shuffle_i).split(X_constrained, y,
+                                                            group_i):
                         self.check_indexing(train_idx)
                         self.check_indexing(test_idx)

--- a/test/test_constrained_dataset.py
+++ b/test/test_constrained_dataset.py
@@ -40,15 +40,16 @@ class TestConstrainedDataset(unittest.TestCase):
 
     def test_getitem(self):
         # test different types of slicing
-        i = np.random.randint(1, c_shape - 1)
-        begin = np.random.randint(1, c_shape - 1)
-        end = np.random.randint(begin + 1, c_shape)
-        fancy_index = np.random.randint(0, c_shape, 20)
-        binary_index = np.random.randint(0, 2, c_shape)
+        i = np.random.randint(1, num_constraints - 1)
+        begin = np.random.randint(1, num_constraints - 1)
+        end = np.random.randint(begin + 1, num_constraints)
+        fancy_index = np.random.randint(0, num_constraints, 20)
+        binary_index = np.random.randint(0, 2, num_constraints)
         boolean_index = binary_index.astype(bool)
-        items = [0, c_shape - 1, i, slice(i), slice(0, begin), slice(begin,
-                 end), slice(end, c_shape), slice(0, c_shape), fancy_index,
-                 binary_index, boolean_index]
+        items = [0, num_constraints - 1, i, slice(i), slice(0, begin),
+                 slice(begin, end), slice(end, num_constraints),
+                 slice(0, num_constraints), fancy_index, binary_index,
+                 boolean_index]
         for item in items:
             self.check_indexing(item)
 

--- a/test/test_constrained_dataset.py
+++ b/test/test_constrained_dataset.py
@@ -159,3 +159,6 @@ class TestSparseConstrainedDataset(_BaseTestConstrainedDataset):
                                                             group_i):
                         self.check_indexing(train_idx)
                         self.check_indexing(test_idx)
+
+if __name__=='__main__':
+    unittest.main()

--- a/test/test_constrained_dataset.py
+++ b/test/test_constrained_dataset.py
@@ -49,14 +49,14 @@ class TestConstrainedDataset(unittest.TestCase):
             self.check_indexing(item)
 
     def test_repr(self):
-        assert repr(cd) == repr(X[c])
+        self.assertEqual(repr(cd), repr(X[c]))
 
     def test_str(self):
-        assert str(cd) == str(X[c])
+        self.assertEqual(str(cd), str(X[c]))
 
     def test_shape(self):
-        assert cd.shape == (c.shape[0], X.shape[1])
-        assert cd[0, 0].shape == (0, X.shape[1])
+        self.assertEqual(cd.shape, (c.shape[0], X.shape[1]))
+        self.assertEqual(cd[0, 0].shape, (0, X.shape[1]))
 
     def test_toarray(self):
         assert_array_equal(cd.toarray(), cd.X[c])

--- a/test/test_constrained_dataset.py
+++ b/test/test_constrained_dataset.py
@@ -1,86 +1,161 @@
 import unittest
 import numpy as np
+import scipy
 from metric_learn.constraints import ConstrainedDataset
 from numpy.testing import assert_array_equal
 from sklearn.model_selection import StratifiedKFold, KFold
 from sklearn.utils import check_random_state
 from sklearn.utils.testing import assert_raise_message
+from sklearn.utils.mocking import MockDataFrame
 
-num_points = 20
-num_features = 5
-num_constraints = 15
-RNG = check_random_state(0)
 
-X = RNG.randn(num_points, num_features)
-c = RNG.randint(0, num_points, (num_constraints, 2))
-X_constrained = ConstrainedDataset(X, c)
-y = RNG.randint(0, 2, num_constraints)
-group = RNG.randint(0, 3, num_constraints)
+class _BaseTestConstrainedDataset(unittest.TestCase):
 
-class TestConstrainedDataset(unittest.TestCase):
+    def setUp(self):
+        self.num_points = 20
+        self.num_features = 5
+        self.num_constraints = 15
+        self.RNG = check_random_state(0)
 
-    @staticmethod
-    def check_indexing(idx):
+        self.c = self.RNG.randint(0, self.num_points,
+                                  (self.num_constraints, 2))
+        self.y = self.RNG.randint(0, 2, self.num_constraints)
+        self.group = self.RNG.randint(0, 3, self.num_constraints)
+
+    def check_indexing(self, idx):
         # checks that an indexing returns the data we expect
-        np.testing.assert_array_equal(X_constrained[idx].c, c[idx])
-        np.testing.assert_array_equal(X_constrained[idx].toarray(), X[c[idx]])
-        np.testing.assert_array_equal(X_constrained[idx].toarray(), X[c][idx])
+        np.testing.assert_array_equal(self.X_constrained[idx].c, self.c[idx])
+        np.testing.assert_array_equal(self.X_constrained[idx].toarray(),
+                                      self.X[self.c[idx]])
+        np.testing.assert_array_equal(self.X_constrained[idx].toarray(),
+                                      self.X[self.c][idx])
+        # checks that slicing does not copy the initial X
+        self.assertTrue(self.X_constrained[idx].X is self.X_constrained.X)
 
     def test_allowed_inputs(self):
         # test the allowed ways to create a ConstrainedDataset
-        ConstrainedDataset(X, c)
+        ConstrainedDataset(self.X, self.c)
 
     def test_invalid_inputs(self):
         # test the invalid ways to create a ConstrainedDataset
         two_points = [[1, 2], [3, 5]]
         out_of_range_constraints = [[1, 2], [0, 1]]
         msg = ("ConstrainedDataset cannot be created: the length of "
-              "the dataset is 2, so index 2 is out of "
-              "range.")
+               "the dataset is 2, so index 2 is out of "
+               "range.")
         assert_raise_message(IndexError, msg, ConstrainedDataset, two_points,
                              out_of_range_constraints)
 
     def test_getitem(self):
         # test different types of slicing
-        i = RNG.randint(1, num_constraints - 1)
-        begin = RNG.randint(1, num_constraints - 1)
-        end = RNG.randint(begin + 1, num_constraints)
-        fancy_index = RNG.randint(0, num_constraints, 20)
-        binary_index = RNG.randint(0, 2, num_constraints)
+        i = self.RNG.randint(1, self.num_constraints - 1)
+        begin = self.RNG.randint(1, self.num_constraints - 1)
+        end = self.RNG.randint(begin + 1, self.num_constraints)
+        fancy_index = self.RNG.randint(0, self.num_constraints, 20)
+        binary_index = self.RNG.randint(0, 2, self.num_constraints)
         boolean_index = binary_index.astype(bool)
-        items = [0, num_constraints - 1, i, slice(i), slice(0, begin),
-                 slice(begin, end), slice(end, num_constraints),
-                 slice(0, num_constraints), fancy_index, binary_index,
-                 boolean_index]
+        items = [0, self.num_constraints - 1, i, slice(i), slice(0, begin),
+                 slice(begin, end), slice(end, self.num_constraints),
+                 slice(0, self.num_constraints), fancy_index,
+                 fancy_index.tolist(), binary_index, binary_index.tolist(),
+                 boolean_index, boolean_index.tolist()]
         for item in items:
             self.check_indexing(item)
 
     def test_repr(self):
-        self.assertEqual(repr(X_constrained), repr(X[c]))
+        self.assertEqual(repr(self.X_constrained), repr(self.X[self.c]))
 
     def test_str(self):
-        self.assertEqual(str(X_constrained), str(X[c]))
+        self.assertEqual(str(self.X_constrained), str(self.X[self.c]))
 
     def test_shape(self):
-        self.assertEqual(X_constrained.shape, (c.shape[0], c.shape[1],
-                                               X.shape[1]))
-        self.assertEqual(X_constrained[0, 0].shape, (0, 0, X.shape[1]))
+        self.assertEqual(self.X_constrained.shape, (self.c.shape[0],
+                                                    self.c.shape[1],
+                                                    self.X.shape[1]))
+        self.assertEqual(self.X_constrained[0, 0].shape,
+                         (0, 0, self.X.shape[1]))
 
     def test_len(self):
-        self.assertEqual(len(X_constrained),c.shape[0])
+        self.assertEqual(len(self.X_constrained), self.c.shape[0])
 
     def test_toarray(self):
-        assert_array_equal(X_constrained.toarray(), X_constrained.X[c])
+        X = self.X_constrained.X
+        assert_array_equal(self.X_constrained.toarray(), X[self.c])
 
     def test_folding(self):
         # test that ConstrainedDataset is compatible with scikit-learn folding
         shuffle_list = [True, False]
-        groups_list = [group, None]
+        groups_list = [self.group, None]
         for alg in [KFold, StratifiedKFold]:
             for shuffle_i in shuffle_list:
                 for group_i in groups_list:
                     for train_idx, test_idx \
-                            in alg(shuffle=shuffle_i).split(X_constrained, y,
+                            in alg(shuffle=shuffle_i).split(self.X_constrained,
+                                                            self.y,
+                                                            group_i):
+                        self.check_indexing(train_idx)
+                        self.check_indexing(test_idx)
+
+
+class TestDenseConstrainedDataset(_BaseTestConstrainedDataset):
+
+    def setUp(self):
+        super(TestDenseConstrainedDataset, self).setUp()
+        self.X = self.RNG.randn(self.num_points, self.num_features)
+        self.X_constrained = ConstrainedDataset(self.X, self.c)
+
+    def test_init(self):
+        """
+        Test alternative ways to initialize a ConstrainedDataset
+        (where the remaining X will stay dense)
+        """
+        X_list = [self.X, self.X.tolist(), list(self.X), MockDataFrame(self.X)]
+        c_list = [self.c, self.c.tolist(), list(self.c), MockDataFrame(self.c)]
+        for X in X_list:
+            for c in c_list:
+                X_constrained = ConstrainedDataset(X, c)
+
+
+class TestSparseConstrainedDataset(_BaseTestConstrainedDataset):
+
+    def setUp(self):
+        super(TestSparseConstrainedDataset, self).setUp()
+        self.X = scipy.sparse.random(self.num_points, self.num_features,
+                                     format='csr', random_state=self.RNG)
+        # todo: for now we test only csr but we should test all sparse types
+        #  in the future
+        self.X_constrained = ConstrainedDataset(self.X, self.c)
+
+    def check_indexing(self, idx):
+        # checks that an indexing returns the data we expect
+        np.testing.assert_array_equal(self.X_constrained[idx].c, self.c[idx])
+        np.testing.assert_array_equal(self.X_constrained[idx].toarray(),
+                                      self.X.A[self.c[idx]])
+        np.testing.assert_array_equal(self.X_constrained[idx].toarray(),
+                                      self.X.A[self.c][idx])
+        # checks that slicing does not copy the initial X
+        self.assertTrue(self.X_constrained[idx].X is self.X_constrained.X)
+
+    def test_repr(self):
+        self.assertEqual(repr(self.X_constrained), repr(self.X.A[self.c]))
+
+    def test_str(self):
+        self.assertEqual(str(self.X_constrained), str(self.X.A[self.c]))
+
+    def test_toarray(self):
+        X = self.X_constrained.X
+        assert_array_equal(self.X_constrained.toarray(), X.A[self.c])
+
+    def test_folding(self):
+        # test that ConstrainedDataset is compatible with scikit-learn folding
+        shuffle_list = [True, False]
+        groups_list = [self.group, None]
+        for alg in [KFold, StratifiedKFold]:
+            for shuffle_i in shuffle_list:
+                for group_i in groups_list:
+                    for train_idx, test_idx \
+                            in alg(shuffle=shuffle_i).split(self.X_constrained,
+                                                            self.y,
                                                             group_i):
                         self.check_indexing(train_idx)
                         self.check_indexing(test_idx)

--- a/test/test_constrained_dataset.py
+++ b/test/test_constrained_dataset.py
@@ -1,0 +1,74 @@
+import unittest
+import numpy as np
+from metric_learn.constraints import ConstrainedDataset
+from numpy.testing import assert_array_equal
+from sklearn.model_selection import StratifiedKFold, KFold
+from sklearn.utils.testing import assert_raise_message
+
+X = np.random.randn(20, 5)
+c = np.random.randint(0, X.shape[0], (15, 2))
+cd = ConstrainedDataset(X, c)
+y = np.random.randint(0, 2, c.shape[0])
+group = np.random.randint(0, 3, c.shape[0])
+
+c_shape = c.shape[0]
+
+
+class TestConstrainedDataset(unittest.TestCase):
+
+    @staticmethod
+    def check_indexing(idx):
+        # checks that an indexing returns the data we expect
+        np.testing.assert_array_equal(cd[idx].c, c[idx])
+        np.testing.assert_array_equal(cd[idx].toarray(), X[c[idx]])
+        np.testing.assert_array_equal(cd[idx].toarray(), X[c][idx])
+
+    def test_inputs(self):
+        # test the allowed and forbidden ways to create a ConstrainedDataset
+        ConstrainedDataset(X, c)
+        two_points = [[1, 2], [3, 5]]
+        out_of_range_constraints = [[1, 2], [0, 1]]
+        msg = "ConstrainedDataset cannot be created: the length of " \
+              "the dataset is 2, so index 2 is out of " \
+              "range."
+        assert_raise_message(IndexError, msg, ConstrainedDataset, two_points,
+                             out_of_range_constraints)
+
+    def test_getitem(self):
+        # test different types of slicing
+        i = np.random.randint(1, c_shape - 1)
+        begin = np.random.randint(1, c_shape - 1)
+        end = np.random.randint(begin + 1, c_shape)
+        fancy_index = np.random.randint(0, c_shape, 20)
+        binary_index = np.random.randint(0, 2, c_shape)
+        boolean_index = binary_index.astype(bool)
+        items = [0, c_shape - 1, i, slice(i), slice(0, begin), slice(begin,
+                 end), slice(end, c_shape), slice(0, c_shape), fancy_index,
+                 binary_index, boolean_index]
+        for item in items:
+            self.check_indexing(item)
+
+    def test_repr(self):
+        assert repr(cd) == repr(X[c])
+
+    def test_str(self):
+        assert str(cd) == str(X[c])
+
+    def test_shape(self):
+        assert cd.shape == (c.shape[0], X.shape[1])
+        assert cd[0, 0].shape == (0, X.shape[1])
+
+    def test_toarray(self):
+        assert_array_equal(cd.toarray(), cd.X[c])
+
+    def test_folding(self):
+        # test that ConstrainedDataset is compatible with scikit-learn folding
+        shuffle_list = [True, False]
+        groups_list = [group, None]
+        for alg in [KFold, StratifiedKFold]:
+            for shuffle_i in shuffle_list:
+                for group_i in groups_list:
+                    for train_idx, test_idx in alg(
+                            shuffle=shuffle_i).split(cd, y, group_i):
+                        self.check_indexing(train_idx)
+                        self.check_indexing(test_idx)

--- a/test/test_constrained_dataset.py
+++ b/test/test_constrained_dataset.py
@@ -31,9 +31,9 @@ class TestConstrainedDataset(unittest.TestCase):
         # test the invalid ways to create a ConstrainedDataset
         two_points = [[1, 2], [3, 5]]
         out_of_range_constraints = [[1, 2], [0, 1]]
-        msg = "ConstrainedDataset cannot be created: the length of " \
-              "the dataset is 2, so index 2 is out of " \
-              "range."
+        msg = ("ConstrainedDataset cannot be created: the length of "
+              "the dataset is 2, so index 2 is out of "
+              "range.")
         assert_raise_message(IndexError, msg, ConstrainedDataset, two_points,
                              out_of_range_constraints)
 

--- a/test/test_weakly_supervised.py
+++ b/test/test_weakly_supervised.py
@@ -1,0 +1,221 @@
+import unittest
+from sklearn import clone
+from sklearn.cluster import KMeans
+from sklearn.model_selection import cross_val_score
+from sklearn.decomposition import PCA
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import make_pipeline
+from sklearn.utils.estimator_checks import is_public_parameter
+from sklearn.utils.testing import set_random_state, assert_true, \
+    assert_allclose_dense_sparse, assert_dict_equal, assert_false
+
+from metric_learn import ITML, LSML, MMC, SDML
+from metric_learn.constraints import ConstrainedDataset
+from sklearn.utils import check_random_state
+import numpy as np
+
+num_points = 100
+num_features = 5
+num_constraints = 100
+
+RNG = check_random_state(0)
+
+X = RNG.randn(num_points, num_features)
+y = RNG.randint(0, 2, num_constraints)
+group = RNG.randint(0, 3, num_constraints)
+
+
+class _TestWeaklySupervisedBase(unittest.TestCase):
+
+    def setUp(self):
+        self.c = RNG.randint(0, num_points, (num_constraints,
+                                             self.num_points_in_constraint))
+        self.X_constrained = ConstrainedDataset(X, self.c)
+        self.X_constrained_train, self.X_constrained_test, self.y_train, \
+        self.y_test = train_test_split(self.X_constrained, y)
+        set_random_state(self.estimator) # sets the algorithm random seed (if
+        #  any)
+
+    def test_cross_validation(self):
+        # test that you can do cross validation on a ConstrainedDataset with
+        #  a WeaklySupervisedMetricLearner
+        estimator = clone(self.estimator)
+        self.assertTrue(np.isfinite(cross_val_score(estimator,
+                                    self.X_constrained, y)).all())
+
+    def check_score(self, estimator, X_constrained, y):
+        score = estimator.score(X_constrained, y)
+        self.assertTrue(np.isfinite(score))
+
+    def check_predict(self, estimator, X_constrained):
+        y_predicted = estimator.predict(X_constrained)
+        self.assertEqual(len(y_predicted), len(X_constrained))
+
+    def check_transform(self, estimator, X_constrained):
+        X_transformed = estimator.transform(X_constrained)
+        self.assertEqual(len(X_transformed), len(X_constrained.X))
+
+    def test_simple_estimator(self):
+        estimator = clone(self.estimator)
+        estimator.fit(self.X_constrained_train, self.y_train)
+        self.check_score(estimator, self.X_constrained_test, self.y_test)
+        self.check_predict(estimator, self.X_constrained_test)
+        self.check_transform(estimator, self.X_constrained_test)
+
+    def test_pipelining_with_transformer(self):
+        """
+        Test that weakly supervised estimators fit well into pipelines
+        """
+        # test in a pipeline with KMeans
+        estimator = clone(self.estimator)
+        pipe = make_pipeline(estimator, KMeans())
+        pipe.fit(self.X_constrained_train, self.y_train)
+        self.check_score(pipe, self.X_constrained_test, self.y_test)
+        self.check_transform(pipe, self.X_constrained_test)
+        # we cannot use check_predict because in this case the shape of the
+        # output is the shape of X_constrained.X, not X_constrained
+        y_predicted = estimator.predict(self.X_constrained)
+        self.assertEqual(len(y_predicted), len(self.X_constrained.X))
+
+        # test in a pipeline with PCA
+        estimator = clone(self.estimator)
+        pipe = make_pipeline(estimator, PCA())
+        pipe.fit(self.X_constrained_train, self.y_train)
+        self.check_transform(pipe, self.X_constrained_test)
+
+    def test_no_fit_attributes_set_in_init(self):
+        """Check that Estimator.__init__ doesn't set trailing-_ attributes."""
+        # From scikit-learn
+        estimator = clone(self.estimator)
+        for attr in dir(estimator):
+            if attr.endswith("_") and not attr.startswith("__"):
+                # This check is for properties, they can be listed in dir
+                # while at the same time have hasattr return False as long
+                # as the property getter raises an AttributeError
+                assert_false(
+                    hasattr(estimator, attr),
+                    "By convention, attributes ending with '_' are "
+                    'estimated from data in scikit-learn. Consequently they '
+                    'should not be initialized in the constructor of an '
+                    'estimator but in the fit method. Attribute {!r} '
+                    'was found in estimator {}'.format(
+                        attr, type(estimator).__name__))
+
+    def test_estimators_fit_returns_self(self):
+        """Check if self is returned when calling fit"""
+        # From scikit-learn
+        estimator = clone(self.estimator)
+        assert_true(estimator.fit(self.X_constrained, y) is estimator)
+
+    def test_pipeline_consistency(self):
+        # From scikit learn
+        # check that make_pipeline(est) gives same score as est
+        estimator = clone(self.estimator)
+        pipeline = make_pipeline(estimator)
+        estimator.fit(self.X_constrained, y)
+        pipeline.fit(self.X_constrained, y)
+
+        funcs = ["score", "fit_transform"]
+
+        for func_name in funcs:
+            func = getattr(estimator, func_name, None)
+            if func is not None:
+                func_pipeline = getattr(pipeline, func_name)
+                result = func(self.X_constrained, y)
+                result_pipe = func_pipeline(self.X_constrained, y)
+                assert_allclose_dense_sparse(result, result_pipe)
+
+    def test_dict_unchanged(self):
+        # From scikit-learn
+        estimator = clone(self.estimator)
+        if hasattr(estimator, "n_components"):
+            estimator.n_components = 1
+        estimator.fit(self.X_constrained, y)
+        for method in ["predict", "transform", "decision_function",
+                       "predict_proba"]:
+            if hasattr(estimator, method):
+                dict_before = estimator.__dict__.copy()
+                getattr(estimator, method)(self.X_constrained)
+                assert_dict_equal(estimator.__dict__, dict_before,
+                                  'Estimator changes __dict__ during %s'
+                                  % method)
+
+    def test_dont_overwrite_parameters(self):
+        # From scikit-learn
+        # check that fit method only changes or sets private attributes
+        estimator = clone(self.estimator)
+        if hasattr(estimator, "n_components"):
+            estimator.n_components = 1
+        dict_before_fit = estimator.__dict__.copy()
+
+        estimator.fit(self.X_constrained, y)
+        dict_after_fit = estimator.__dict__
+
+        public_keys_after_fit = [key for key in dict_after_fit.keys()
+                                 if is_public_parameter(key)]
+
+        attrs_added_by_fit = [key for key in public_keys_after_fit
+                              if key not in dict_before_fit.keys()]
+
+        # check that fit doesn't add any public attribute
+        assert_true(not attrs_added_by_fit,
+                    ('Estimator adds public attribute(s) during'
+                     ' the fit method.'
+                     ' Estimators are only allowed to add private '
+                     'attributes'
+                     ' either started with _ or ended'
+                     ' with _ but %s added' % ', '.join(
+                        attrs_added_by_fit)))
+
+        # check that fit doesn't change any public attribute
+        attrs_changed_by_fit = [key for key in public_keys_after_fit
+                                if (dict_before_fit[key]
+                                    is not dict_after_fit[key])]
+
+        assert_true(not attrs_changed_by_fit,
+                    ('Estimator changes public attribute(s) during'
+                     ' the fit method. Estimators are only allowed'
+                     ' to change attributes started'
+                     ' or ended with _, but'
+                     ' %s changed' % ', '.join(attrs_changed_by_fit)))
+
+class _TestPairsBase(_TestWeaklySupervisedBase):
+    
+    def setUp(self):
+        self.num_points_in_constraint = 2
+        super(_TestPairsBase, self).setUp()
+
+
+class _TestQuadrupletsBase(_TestWeaklySupervisedBase):
+
+    def setUp(self):
+        self.num_points_in_constraint = 4
+        super(_TestQuadrupletsBase, self).setUp()
+
+
+class TestITML(_TestPairsBase):
+    
+    def setUp(self):
+        self.estimator = ITML()
+        super(TestITML, self).setUp()
+
+
+class TestLSML(_TestQuadrupletsBase):
+
+    def setUp(self):
+        self.estimator = LSML()
+        super(TestLSML, self).setUp()
+
+
+class TestMMC(_TestPairsBase):
+    
+    def setUp(self):
+        self.estimator = MMC()
+        super(TestMMC, self).setUp()
+
+        
+class TestSDML(_TestPairsBase):
+    
+    def setUp(self):
+        self.estimator = SDML()
+        super(TestSDML, self).setUp()


### PR DESCRIPTION
This PR intends to provide a new API for the package, that would allow to use scikit-learn's tools for model selection and pipelining not only for supervised algorithms but also for weakly supervised ones. Indeed we would like to be able for instance to have a dataset of pairs, an algorithm that works on labeled pairs (i.e. pairwise constraints) and plug it into say scikit-learn's 'roc_auc' cross-validation scoring. This cross-validation scoring would split on the **pairs** and return the score of a classification of **pairs**. However we don't want to build an explicit dataset of pairs: indeed if we duplicate a point as many times as it is involved in a pair, the dataset would be huge. Instead, we would build a object that acts **as if** it was a list of pairs, but in fact stores the initial dataset as well as indices. The behaviour of such an object and use basic use cases can be found in this binder notebook: [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/wdevazelhes/api_metric_learn/master).

This PR will be complete when the following will be done: 

- [X] Keep the same API but introduce the objects that will be used in the new API
- [ ] Create an object ConstrainedDataset that will allow the behaviour presented in the description
- [X] Modify existing algorithms to use this object. The API will then be changed (only for algorithms that take as an input an some labeled pairs of samples instead of labeled samples).
- [X] Write the appropriate documentation

