### PR TITLE
[MRG] move from unittest to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
   - pip install --upgrade pip
   - pip install wheel
   - pip install numpy scipy scikit-learn
-script: python setup.py test
+script: pytest test

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,8 @@ Run ``pip install metric-learn`` to download and install from PyPI.
 
 Run ``python setup.py install`` for default installation.
 
-Run ``python setup.py test`` to run all tests.
+Run ``pytest test`` to run all tests (you will need to have the ``pytest``
+package installed).
 
 **Usage**
 


### PR DESCRIPTION
This PR replaces unittest by pytest. Pytest is more and more used and provides a flexible and advanced framework for testing. It is still compatible with unittests so the project testing would still work after this PR is merged. It would allow to code future tests for the new API in pytest.