### PR TITLE
[MRG + 1] Allow already formed tuples as an input.

### DIFF
--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -100,3 +100,13 @@ class Constraints(object):
     partial_labels = np.array(all_labels, copy=True)
     partial_labels[idx] = -1
     return Constraints(partial_labels)
+
+def wrap_pairs(X, constraints):
+  a = np.array(constraints[0])
+  b = np.array(constraints[1])
+  c = np.array(constraints[2])
+  d = np.array(constraints[3])
+  constraints = np.vstack((np.column_stack((a, b)), np.column_stack((c, d))))
+  y = np.vstack([np.ones((len(a), 1)), np.zeros((len(c), 1))])
+  pairs = X[constraints]
+  return pairs, y

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -107,6 +107,6 @@ def wrap_pairs(X, constraints):
   c = np.array(constraints[2])
   d = np.array(constraints[3])
   constraints = np.vstack((np.column_stack((a, b)), np.column_stack((c, d))))
-  y = np.vstack([np.ones((len(a), 1)), np.zeros((len(c), 1))])
+  y = np.vstack([np.ones((len(a), 1)), - np.ones((len(c), 1))])
   pairs = X[constraints]
   return pairs, y

--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -54,10 +54,9 @@ class ITML(BaseMetricLearner):
   def _process_pairs(self, pairs, y, bounds):
     pairs, y = check_X_y(pairs, y, accept_sparse=False,
                                       ensure_2d=False, allow_nd=True)
-    y = y.astype(bool)
 
     # check to make sure that no two constrained vectors are identical
-    pos_pairs, neg_pairs = pairs[y], pairs[~y]
+    pos_pairs, neg_pairs = pairs[y == 1], pairs[y == -1]
     pos_no_ident = vector_norm(pos_pairs[:, 0, :] - pos_pairs[:, 1, :]) > 1e-9
     pos_pairs = pos_pairs[pos_no_ident]
     neg_no_ident = vector_norm(neg_pairs[:, 0, :] - neg_pairs[:, 1, :]) > 1e-9
@@ -76,8 +75,7 @@ class ITML(BaseMetricLearner):
     else:
       self.A_ = check_array(self.A0)
     pairs = np.vstack([pos_pairs, neg_pairs])
-    y = np.hstack([np.ones(len(pos_pairs)), np.zeros(len(neg_pairs))])
-    y = y.astype(bool)
+    y = np.hstack([np.ones(len(pos_pairs)), - np.ones(len(neg_pairs))])
     return pairs, y
 
 
@@ -100,7 +98,7 @@ class ITML(BaseMetricLearner):
     """
     pairs, y = self._process_pairs(pairs, y, bounds)
     gamma = self.gamma
-    pos_pairs, neg_pairs = pairs[y], pairs[~y]
+    pos_pairs, neg_pairs = pairs[y == 1], pairs[y == -1]
     num_pos = len(pos_pairs)
     num_neg = len(neg_pairs)
     _lambda = np.zeros(num_pos + num_neg)

--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -87,7 +87,7 @@ class ITML(BaseMetricLearner):
     pairs: array-like, shape=(n_constraints, 2, n_features)
         Array of pairs. Each row corresponds to two points.
     y: array-like, of shape (n_constraints,)
-        Labels of constraints. Should be 0 for dissimilar pair, 1 for similar.
+        Labels of constraints. Should be -1 for dissimilar pair, 1 for similar.
     bounds : list (pos,neg) pairs, optional
         bounds on similarity, s.t. d(X[a],X[b]) < pos and d(X[c],X[d]) > neg
 

--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -64,7 +64,7 @@ class ITML(BaseMetricLearner):
     neg_pairs = neg_pairs[neg_no_ident]
     # init bounds
     if bounds is None:
-      X = np.unique(pairs.reshape(-1, pairs.shape[2]), axis=0)
+      X = np.vstack({tuple(row) for row in pairs.reshape(-1, pairs.shape[2])})
       self.bounds_ = np.percentile(pairwise_distances(X), (5, 95))
     else:
       assert len(bounds) == 2

--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -20,7 +20,7 @@ from sklearn.metrics import pairwise_distances
 from sklearn.utils.validation import check_array, check_X_y
 
 from .base_metric import BaseMetricLearner
-from .constraints import Constraints
+from .constraints import Constraints, wrap_pairs
 from ._util import vector_norm
 
 
@@ -51,16 +51,20 @@ class ITML(BaseMetricLearner):
     self.A0 = A0
     self.verbose = verbose
 
-  def _process_inputs(self, X, constraints, bounds):
-    self.X_ = X = check_array(X)
+  def _process_pairs(self, pairs, y, bounds):
+    pairs, y = check_X_y(pairs, y, accept_sparse=False,
+                                      ensure_2d=False, allow_nd=True)
+    y = y.astype(bool)
+
     # check to make sure that no two constrained vectors are identical
-    a,b,c,d = constraints
-    no_ident = vector_norm(X[a] - X[b]) > 1e-9
-    a, b = a[no_ident], b[no_ident]
-    no_ident = vector_norm(X[c] - X[d]) > 1e-9
-    c, d = c[no_ident], d[no_ident]
+    pos_pairs, neg_pairs = pairs[y], pairs[~y]
+    pos_no_ident = vector_norm(pos_pairs[:, 0, :] - pos_pairs[:, 1, :]) > 1e-9
+    pos_pairs = pos_pairs[pos_no_ident]
+    neg_no_ident = vector_norm(neg_pairs[:, 0, :] - neg_pairs[:, 1, :]) > 1e-9
+    neg_pairs = neg_pairs[neg_no_ident]
     # init bounds
     if bounds is None:
+      X = np.unique(pairs.reshape(-1, pairs.shape[2]), axis=0)
       self.bounds_ = np.percentile(pairwise_distances(X), (5, 95))
     else:
       assert len(bounds) == 2
@@ -68,12 +72,16 @@ class ITML(BaseMetricLearner):
     self.bounds_[self.bounds_==0] = 1e-9
     # init metric
     if self.A0 is None:
-      self.A_ = np.identity(X.shape[1])
+      self.A_ = np.identity(pairs.shape[2])
     else:
       self.A_ = check_array(self.A0)
-    return a,b,c,d
+    pairs = np.vstack([pos_pairs, neg_pairs])
+    y = np.hstack([np.ones(len(pos_pairs)), np.zeros(len(neg_pairs))])
+    y = y.astype(bool)
+    return pairs, y
 
-  def fit(self, X, constraints, bounds=None):
+
+  def fit(self, pairs, y, bounds=None):
     """Learn the ITML model.
 
     Parameters
@@ -86,17 +94,18 @@ class ITML(BaseMetricLearner):
     bounds : list (pos,neg) pairs, optional
         bounds on similarity, s.t. d(X[a],X[b]) < pos and d(X[c],X[d]) > neg
     """
-    a,b,c,d = self._process_inputs(X, constraints, bounds)
+    pairs, y = self._process_pairs(pairs, y, bounds)
     gamma = self.gamma
-    num_pos = len(a)
-    num_neg = len(c)
+    pos_pairs, neg_pairs = pairs[y], pairs[~y]
+    num_pos = len(pos_pairs)
+    num_neg = len(neg_pairs)
     _lambda = np.zeros(num_pos + num_neg)
     lambdaold = np.zeros_like(_lambda)
     gamma_proj = 1. if gamma is np.inf else gamma/(gamma+1.)
     pos_bhat = np.zeros(num_pos) + self.bounds_[0]
     neg_bhat = np.zeros(num_neg) + self.bounds_[1]
-    pos_vv = self.X_[a] - self.X_[b]
-    neg_vv = self.X_[c] - self.X_[d]
+    pos_vv = pos_pairs[:, 0, :] - pos_pairs[:, 1, :]
+    neg_vv = neg_pairs[:, 0, :] - neg_pairs[:, 1, :]
     A = self.A_
 
     for it in xrange(self.max_iter):
@@ -195,4 +204,5 @@ class ITML_Supervised(ITML):
                                   random_state=random_state)
     pos_neg = c.positive_negative_pairs(num_constraints,
                                         random_state=random_state)
-    return ITML.fit(self, X, pos_neg, bounds=self.bounds)
+    pairs, y = wrap_pairs(X, pos_neg)
+    return ITML.fit(self, pairs, y, bounds=self.bounds)

--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -86,13 +86,17 @@ class ITML(BaseMetricLearner):
 
     Parameters
     ----------
-    X : (n x d) data matrix
-        each row corresponds to a single instance
-    constraints : 4-tuple of arrays
-        (a,b,c,d) indices into X, with (a,b) specifying positive and (c,d)
-        negative pairs
+    pairs: array-like, shape=(n_constraints, 2, n_features)
+        Array of pairs. Each row corresponds to two points.
+    y: array-like, of shape (n_constraints,)
+        Labels of constraints. Should be 0 for dissimilar pair, 1 for similar.
     bounds : list (pos,neg) pairs, optional
         bounds on similarity, s.t. d(X[a],X[b]) < pos and d(X[c],X[d]) > neg
+
+    Returns
+    -------
+    self : object
+        Returns the instance.
     """
     pairs, y = self._process_pairs(pairs, y, bounds)
     gamma = self.gamma

--- a/metric_learn/lfda.py
+++ b/metric_learn/lfda.py
@@ -139,10 +139,11 @@ def _sum_outer(x):
 def _eigh(a, b, dim):
   try:
     return scipy.sparse.linalg.eigsh(a, k=dim, M=b, which='LA')
-  except (ValueError, scipy.sparse.linalg.ArpackNoConvergence):
-    pass
-  try:
-    return scipy.linalg.eigh(a, b)
   except np.linalg.LinAlgError:
-    pass
+    pass  # scipy already tried eigh for us
+  except (ValueError, scipy.sparse.linalg.ArpackNoConvergence):
+    try:
+      return scipy.linalg.eigh(a, b)
+    except np.linalg.LinAlgError:
+      pass
   return scipy.linalg.eig(a, b)

--- a/metric_learn/lsml.py
+++ b/metric_learn/lsml.py
@@ -65,12 +65,18 @@ class LSML(BaseMetricLearner):
 
     Parameters
     ----------
-    X : (n x d) data matrix
-        each row corresponds to a single instance
-    constraints : 4-tuple of arrays
-        (a,b,c,d) indices into X, such that d(X[a],X[b]) < d(X[c],X[d])
-    weights : (m,) array of floats, optional
+    quadruplets : array-like, shape=(n_constraints, 4, n_features)
+        Each row corresponds to 4 points. In order to supervise the
+        algorithm in the right way, we should have the four samples ordered
+        in a way such that: d(pairs[i, 0],X[i, 1]) < d(X[i, 2], X[i, 3])
+        for all 0 <= i < n_constraints.
+    weights : (n_constraints,) array of floats, optional
         scale factor for each constraint
+
+    Returns
+    -------
+    self : object
+        Returns the instance.
     """
     self._prepare_quadruplets(quadruplets, weights)
     step_sizes = np.logspace(-10, 0, 10)

--- a/metric_learn/lsml.py
+++ b/metric_learn/lsml.py
@@ -50,7 +50,7 @@ class LSML(BaseMetricLearner):
       self.w_ = weights
     self.w_ /= self.w_.sum()  # weights must sum to 1
     if self.prior is None:
-      X = np.unique(pairs.reshape(-1, pairs.shape[2]), axis=0)
+      X = np.vstack({tuple(row) for row in pairs.reshape(-1, pairs.shape[2])})
       self.prior_inv_ = np.atleast_2d(np.cov(X, rowvar=False))
       self.M_ = np.linalg.inv(self.prior_inv_)
     else:

--- a/metric_learn/mmc.py
+++ b/metric_learn/mmc.py
@@ -83,10 +83,9 @@ class MMC(BaseMetricLearner):
   def _process_pairs(self, pairs, y):
     pairs, y = check_X_y(pairs, y, accept_sparse=False,
                                       ensure_2d=False, allow_nd=True)
-    y = y.astype(bool)
 
     # check to make sure that no two constrained vectors are identical
-    pos_pairs, neg_pairs = pairs[y], pairs[~y]
+    pos_pairs, neg_pairs = pairs[y == 1], pairs[y == -1]
     pos_no_ident = vector_norm(pos_pairs[:, 0, :] - pos_pairs[:, 1, :]) > 1e-9
     pos_pairs = pos_pairs[pos_no_ident]
     neg_no_ident = vector_norm(neg_pairs[:, 0, :] - neg_pairs[:, 1, :]) > 1e-9
@@ -107,8 +106,7 @@ class MMC(BaseMetricLearner):
       self.A_ = check_array(self.A0)
 
     pairs = np.vstack([pos_pairs, neg_pairs])
-    y = np.hstack([np.ones(len(pos_pairs)), np.zeros(len(neg_pairs))])
-    y = y.astype(bool)
+    y = np.hstack([np.ones(len(pos_pairs)), - np.ones(len(neg_pairs))])
     return pairs, y
 
   def _fit_full(self, pairs, y):
@@ -128,7 +126,7 @@ class MMC(BaseMetricLearner):
     eps = 0.01        # error-bound of iterative projection on C1 and C2
     A = self.A_
 
-    pos_pairs, neg_pairs = pairs[y], pairs[~y]
+    pos_pairs, neg_pairs = pairs[y == 1], pairs[y == -1]
 
     # Create weight vector from similar samples
     pos_diff = pos_pairs[:, 0, :] - pos_pairs[:, 1, :]
@@ -244,7 +242,7 @@ class MMC(BaseMetricLearner):
         dissimilar pairs
     """
     num_dim = pairs.shape[2]
-    pos_pairs, neg_pairs = pairs[y], pairs[~y]
+    pos_pairs, neg_pairs = pairs[y == 1], pairs[y == -1]
     s_sum = np.sum((pos_pairs[:, 0, :] - pos_pairs[:, 1, :]) ** 2, axis=0)
 
     it = 0

--- a/metric_learn/mmc.py
+++ b/metric_learn/mmc.py
@@ -64,11 +64,15 @@ class MMC(BaseMetricLearner):
 
     Parameters
     ----------
-    X : (n x d) data matrix
-        each row corresponds to a single instance
-    constraints : 4-tuple of arrays
-        (a,b,c,d) indices into X, with (a,b) specifying similar and (c,d)
-        dissimilar pairs
+    pairs: array-like, shape=(n_constraints, 2, n_features)
+        Array of pairs. Each row corresponds to two points.
+    y: array-like, of shape (n_constraints,)
+        Labels of constraints. Should be 0 for dissimilar pair, 1 for similar.
+
+    Returns
+    -------
+    self : object
+        Returns the instance.
     """
     pairs, y = self._process_pairs(pairs, y)
     if self.diagonal:

--- a/metric_learn/mmc.py
+++ b/metric_learn/mmc.py
@@ -67,7 +67,7 @@ class MMC(BaseMetricLearner):
     pairs: array-like, shape=(n_constraints, 2, n_features)
         Array of pairs. Each row corresponds to two points.
     y: array-like, of shape (n_constraints,)
-        Labels of constraints. Should be 0 for dissimilar pair, 1 for similar.
+        Labels of constraints. Should be -1 for dissimilar pair, 1 for similar.
 
     Returns
     -------

--- a/metric_learn/sdml.py
+++ b/metric_learn/sdml.py
@@ -62,10 +62,10 @@ class SDML(BaseMetricLearner):
 
     Parameters
     ----------
-    X : array-like, shape (n, d)
-        data matrix, where each row corresponds to a single instance
-    W : array-like, shape (n, n)
-        connectivity graph, with +1 for positive pairs and -1 for negative
+    pairs: array-like, shape=(n_constraints, 2, n_features)
+        Array of pairs. Each row corresponds to two points.
+    y: array-like, of shape (n_constraints,)
+        Labels of constraints. Should be 0 for dissimilar pair, 1 for similar.
 
     Returns
     -------

--- a/metric_learn/sdml.py
+++ b/metric_learn/sdml.py
@@ -135,5 +135,4 @@ class SDML_Supervised(SDML):
     pos_neg = c.positive_negative_pairs(num_constraints,
                                               random_state=random_state)
     pairs, y = wrap_pairs(X, pos_neg)
-    y = 2 * y - 1
     return SDML.fit(self, pairs, y)

--- a/metric_learn/sdml.py
+++ b/metric_learn/sdml.py
@@ -65,7 +65,7 @@ class SDML(BaseMetricLearner):
     pairs: array-like, shape=(n_constraints, 2, n_features)
         Array of pairs. Each row corresponds to two points.
     y: array-like, of shape (n_constraints,)
-        Labels of constraints. Should be 0 for dissimilar pair, 1 for similar.
+        Labels of constraints. Should be -1 for dissimilar pair, 1 for similar.
 
     Returns
     -------

--- a/metric_learn/sdml.py
+++ b/metric_learn/sdml.py
@@ -47,7 +47,7 @@ class SDML(BaseMetricLearner):
                                       ensure_2d=False, allow_nd=True)
     # set up prior M
     if self.use_cov:
-      X = np.unique(pairs.reshape(-1, pairs.shape[2]), axis=0)
+      X = np.vstack({tuple(row) for row in pairs.reshape(-1, pairs.shape[2])})
       self.M_ = pinvh(np.cov(X, rowvar = False))
     else:
       self.M_ = np.identity(pairs.shape[2])

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -9,6 +9,7 @@ from metric_learn import (
     LMNN, NCA, LFDA, Covariance, MLKR, MMC,
     LSML_Supervised, ITML_Supervised, SDML_Supervised, RCA_Supervised, MMC_Supervised)
 # Import this specially for testing.
+from metric_learn.constraints import wrap_pairs
 from metric_learn.lmnn import python_LMNN
 
 
@@ -47,7 +48,7 @@ class TestLSML(MetricTestCase):
     lsml = LSML_Supervised(num_constraints=200)
     lsml.fit(self.iris_points, self.iris_labels)
 
-    csep = class_separation(lsml.transform(), self.iris_labels)
+    csep = class_separation(lsml.transform(self.iris_points), self.iris_labels)
     self.assertLess(csep, 0.8)  # it's pretty terrible
 
 
@@ -56,7 +57,7 @@ class TestITML(MetricTestCase):
     itml = ITML_Supervised(num_constraints=200)
     itml.fit(self.iris_points, self.iris_labels)
 
-    csep = class_separation(itml.transform(), self.iris_labels)
+    csep = class_separation(itml.transform(self.iris_points), self.iris_labels)
     self.assertLess(csep, 0.2)
 
 
@@ -79,7 +80,7 @@ class TestSDML(MetricTestCase):
 
     sdml = SDML_Supervised(num_constraints=1500)
     sdml.fit(self.iris_points, self.iris_labels, random_state=rs)
-    csep = class_separation(sdml.transform(), self.iris_labels)
+    csep = class_separation(sdml.transform(self.iris_points), self.iris_labels)
     self.assertLess(csep, 0.25)
 
 
@@ -160,7 +161,7 @@ class TestMMC(MetricTestCase):
 
     # Full metric
     mmc = MMC(convergence_threshold=0.01)
-    mmc.fit(self.iris_points, [a,b,c,d])
+    mmc.fit(*wrap_pairs(self.iris_points, [a,b,c,d]))
     expected = [[+0.00046504, +0.00083371, -0.00111959, -0.00165265],
                 [+0.00083371, +0.00149466, -0.00200719, -0.00296284],
                 [-0.00111959, -0.00200719, +0.00269546, +0.00397881],
@@ -169,20 +170,20 @@ class TestMMC(MetricTestCase):
 
     # Diagonal metric
     mmc = MMC(diagonal=True)
-    mmc.fit(self.iris_points, [a,b,c,d])
+    mmc.fit(*wrap_pairs(self.iris_points, [a,b,c,d]))
     expected = [0, 0, 1.21045968, 1.22552608]
     assert_array_almost_equal(np.diag(expected), mmc.metric(), decimal=6)
     
     # Supervised Full
     mmc = MMC_Supervised()
     mmc.fit(self.iris_points, self.iris_labels)
-    csep = class_separation(mmc.transform(), self.iris_labels)
+    csep = class_separation(mmc.transform(self.iris_points), self.iris_labels)
     self.assertLess(csep, 0.15)
     
     # Supervised Diagonal
     mmc = MMC_Supervised(diagonal=True)
     mmc.fit(self.iris_points, self.iris_labels)
-    csep = class_separation(mmc.transform(), self.iris_labels)
+    csep = class_separation(mmc.transform(self.iris_points), self.iris_labels)
     self.assertLess(csep, 0.2)
 
 

--- a/test/test_fit_transform.py
+++ b/test/test_fit_transform.py
@@ -30,7 +30,7 @@ class TestFitTransform(unittest.TestCase):
     seed = np.random.RandomState(1234)
     lsml = LSML_Supervised(num_constraints=200)
     lsml.fit(self.X, self.y, random_state=seed)
-    res_1 = lsml.transform()
+    res_1 = lsml.transform(self.X)
 
     seed = np.random.RandomState(1234)
     lsml = LSML_Supervised(num_constraints=200)
@@ -42,7 +42,7 @@ class TestFitTransform(unittest.TestCase):
     seed = np.random.RandomState(1234)
     itml = ITML_Supervised(num_constraints=200)
     itml.fit(self.X, self.y, random_state=seed)
-    res_1 = itml.transform()
+    res_1 = itml.transform(self.X)
 
     seed = np.random.RandomState(1234)
     itml = ITML_Supervised(num_constraints=200)
@@ -64,7 +64,7 @@ class TestFitTransform(unittest.TestCase):
     seed = np.random.RandomState(1234)
     sdml = SDML_Supervised(num_constraints=1500)
     sdml.fit(self.X, self.y, random_state=seed)
-    res_1 = sdml.transform()
+    res_1 = sdml.transform(self.X)
 
     seed = np.random.RandomState(1234)
     sdml = SDML_Supervised(num_constraints=1500)
@@ -122,7 +122,7 @@ class TestFitTransform(unittest.TestCase):
     seed = np.random.RandomState(1234)
     mmc = MMC_Supervised(num_constraints=200)
     mmc.fit(self.X, self.y, random_state=seed)
-    res_1 = mmc.transform()
+    res_1 = mmc.transform(self.X)
 
     seed = np.random.RandomState(1234)
     mmc = MMC_Supervised(num_constraints=200)


### PR DESCRIPTION
This PR changes the API with the first and easier case to implement of the new api (see issue https://github.com/metric-learn/metric-learn/issues/91 ): the case where there is no preprocessor but tuples are already formed and given to the algorithm as such. The main question is for algorithms that needs a covariance matrix to initialize the metric (LSML), or that compute bounds (ITML). For now I just reconstruct a dataset of points from the pairs thanks to np.unique, in order to have the same results and pass the tests, but this is probably not the best thing to do. For SDML, I could express the term involved in the loss only with formed pairs instead of datapoints, and here is a snippet that tests it: https://gist.github.com/wdevazelhes/3c349e13976613d15ebc46178c942474

Left TODO:
- [x] Update docstrings of methods where signature changed