### PR TITLE
[MRG] Add memory efficient implementation of NCA

### DIFF
--- a/metric_learn/nca.py
+++ b/metric_learn/nca.py
@@ -5,14 +5,11 @@ Ported to Python from https://github.com/vomjom/nca
 
 from __future__ import absolute_import
 
-import sys
-import time
 import warnings
 import numpy as np
 from scipy.optimize import minimize
-from sklearn.decomposition import PCA
 from sklearn.metrics import pairwise_distances
-from sklearn.utils.validation import check_X_y, check_random_state
+from sklearn.utils.validation import check_X_y
 
 try:  # scipy.misc.logsumexp is deprecated in scipy 1.0.0
     from scipy.special import logsumexp
@@ -26,11 +23,10 @@ EPS = np.finfo(float).eps
 
 class NCA(BaseMetricLearner):
   def __init__(self, num_dims=None, max_iter=100, learning_rate='deprecated',
-               random_state=0, tol=None):
+               tol=None):
     self.num_dims = num_dims
     self.max_iter = max_iter
     self.learning_rate = learning_rate  # TODO: remove in v.0.5.0
-    self.random_state = random_state
     self.tol = tol
 
   def transformer(self):
@@ -45,9 +41,6 @@ class NCA(BaseMetricLearner):
       warnings.warn('"learning_rate" parameter is not used.'
                     ' It has been deprecated in version 0.4 and will be'
                     'removed in 0.5', DeprecationWarning)
-
-    # Initialize the random generator
-    self.random_state_ = check_random_state(self.random_state)
 
     X, labels = check_X_y(X, y)
     n, d = X.shape

--- a/metric_learn/nca.py
+++ b/metric_learn/nca.py
@@ -61,7 +61,7 @@ class NCA(BaseMetricLearner):
     np.fill_diagonal(A, 1./(np.maximum(X.max(axis=0)-X.min(axis=0), EPS)))
 
     # Run NCA
-    mask = y[:, np.newaxis] == y[np.newaxis, :]
+    mask = labels[:, np.newaxis] == labels[np.newaxis, :]
     optimizer_params = {'method': 'L-BFGS-B',
                         'fun': self._loss_grad_lbfgs,
                         'args': (X, mask, -1.0),

--- a/metric_learn/nca.py
+++ b/metric_learn/nca.py
@@ -24,6 +24,27 @@ EPS = np.finfo(float).eps
 class NCA(BaseMetricLearner):
   def __init__(self, num_dims=None, max_iter=100, learning_rate='deprecated',
                tol=None):
+    """Neighborhood Components Analysis
+
+    Parameters
+    ----------
+    num_dims : int, optional (default=None)
+      Embedding dimensionality. If None, will be set to ``n_features``
+      (``d``) at fit time.
+
+    max_iter : int, optional (default=100)
+      Maximum number of iterations done by the optimization algorithm.
+
+    learning_rate : Not used
+
+      .. deprecated:: 0.4.0
+        `learning_rate` was deprecated in version 0.4.0 and will
+        be removed in 0.5.0. The current optimization algorithm does not need
+        to fix a learning rate.
+
+    tol : float, optional (default=None)
+        Convergence tolerance for the optimization.
+    """
     self.num_dims = num_dims
     self.max_iter = max_iter
     self.learning_rate = learning_rate  # TODO: remove in v.0.5.0

--- a/metric_learn/nca.py
+++ b/metric_learn/nca.py
@@ -4,9 +4,20 @@ Ported to Python from https://github.com/vomjom/nca
 """
 
 from __future__ import absolute_import
+
+import sys
+import time
+import warnings
 import numpy as np
-from six.moves import xrange
-from sklearn.utils.validation import check_X_y
+from scipy.optimize import minimize
+from sklearn.decomposition import PCA
+from sklearn.metrics import pairwise_distances
+from sklearn.utils.validation import check_X_y, check_random_state
+
+try:  # scipy.misc.logsumexp is deprecated in scipy 1.0.0
+    from scipy.special import logsumexp
+except ImportError:
+    from scipy.misc import logsumexp
 
 from .base_metric import BaseMetricLearner
 
@@ -14,10 +25,14 @@ EPS = np.finfo(float).eps
 
 
 class NCA(BaseMetricLearner):
-  def __init__(self, num_dims=None, max_iter=100, learning_rate=0.01):
+  def __init__(self, num_dims=None, max_iter=100, learning_rate='deprecated',
+               init='auto', random_state=0, verbose=False):
     self.num_dims = num_dims
     self.max_iter = max_iter
-    self.learning_rate = learning_rate
+    self.learning_rate = learning_rate  # TODO: remove in v.0.5.0
+    self.init = init
+    self.random_state = 0
+    self.verbose = 0
 
   def transformer(self):
     return self.A_
@@ -27,33 +42,122 @@ class NCA(BaseMetricLearner):
     X: data matrix, (n x d)
     y: scalar labels, (n)
     """
+    if self.learning_rate != 'deprecated':
+      warnings.warn('"learning_rate" parameter is not used.'
+                    ' It has been deprecated in version 0.4 and will be'
+                    'removed in 0.5', DeprecationWarning)
+
+    # Initialize the random generator
+    self.random_state_ = check_random_state(self.random_state)
+
     X, labels = check_X_y(X, y)
     n, d = X.shape
     num_dims = self.num_dims
     if num_dims is None:
         num_dims = d
-    # Initialize A to a scaling matrix
-    A = np.zeros((num_dims, d))
-    np.fill_diagonal(A, 1./(np.maximum(X.max(axis=0)-X.min(axis=0), EPS)))
+
+    A = self._initialize(X, y, self.init)
 
     # Run NCA
-    dX = X[:,None] - X[None]  # shape (n, n, d)
-    tmp = np.einsum('...i,...j->...ij', dX, dX)  # shape (n, n, d, d)
-    masks = labels[:,None] == labels[None]
-    for it in xrange(self.max_iter):
-      for i, label in enumerate(labels):
-        mask = masks[i]
-        Ax = A.dot(X.T).T  # shape (n, num_dims)
+    mask = y[:, np.newaxis] == y[np.newaxis, :]
+    optimizer_params = {'method': 'L-BFGS-B',
+                        'fun': self._loss_grad_lbfgs,
+                        'args': (X, mask, -1.0),
+                        'jac': True,
+                        'x0': A.ravel(),
+                        'options': dict(maxiter=self.max_iter),
+                        }
 
-        softmax = np.exp(-((Ax[i] - Ax)**2).sum(axis=1))  # shape (n)
-        softmax[i] = 0
-        softmax /= softmax.sum()
-
-        t = softmax[:, None, None] * tmp[i]  # shape (n, d, d)
-        d = softmax[mask].sum() * t.sum(axis=0) - t[mask].sum(axis=0)
-        A += self.learning_rate * A.dot(d)
+    # Call the optimizer
+    opt_result = minimize(**optimizer_params)
 
     self.X_ = X
-    self.A_ = A
-    self.n_iter_ = it
+    self.A_ = opt_result.x.reshape(num_dims, -1)
+    self.n_iter_ = opt_result.nit
     return self
+
+  @staticmethod
+  def _loss_grad_lbfgs(A, X, mask, sign=1.0):
+    A = A.reshape(-1, X.shape[1])
+    X_embedded = np.dot(X, A.T)  # (n_samples, num_dims)
+    # Compute softmax distances
+    p_ij = pairwise_distances(X_embedded, squared=True)
+    np.fill_diagonal(p_ij, np.inf)
+    p_ij = np.exp(-p_ij - logsumexp(-p_ij, axis=1)[:, np.newaxis])
+    # (n_samples, n_samples)
+
+    # Compute loss
+    masked_p_ij = p_ij * mask
+    p = np.sum(masked_p_ij, axis=1, keepdims=True)  # (n_samples, 1)
+    loss = np.sum(p)
+
+    # Compute gradient of loss w.r.t. `transform`
+    weighted_p_ij = masked_p_ij - p_ij * p
+    gradient = 2 * (X_embedded.T.dot(weighted_p_ij + weighted_p_ij.T) -
+                    X_embedded.T * np.sum(weighted_p_ij, axis=0)).dot(X)
+    return sign * loss, sign * gradient.ravel()
+
+  def _initialize(self, X, y, init):
+    """Initialize the transformation.
+
+    Parameters
+    ----------
+    X : array-like, shape (n_samples, n_features)
+        The training samples.
+
+    y : array-like, shape (n_samples,)
+        The training labels.
+
+    init : string or numpy array of shape (n_features_a, n_features_b)
+        The validated initialization of the linear transformation.
+
+    Returns
+    -------
+    transformation : array, shape (n_components, n_features)
+        The initialized linear transformation.
+
+    """
+
+    transformation = init
+
+    if isinstance(init, np.ndarray):
+      pass
+    else:
+      n_samples, n_features = X.shape
+      n_components = self.num_dims or n_features
+      if init == 'auto':
+        n_classes = len(np.unique(y))
+        if num_dims <= n_classes:
+          init = 'lda'
+        elif num_dims < min(n_features, n_samples):
+          init = 'pca'
+        else:
+          init = 'identity'
+      if init == 'identity':
+        transformation = np.eye(num_dims, X.shape[1])
+      elif init == 'random':
+        transformation = self.random_state_.randn(num_dims,
+                                                  X.shape[1])
+      elif init in {'pca', 'lda'}:
+        init_time = time.time()
+        if init == 'pca':
+          pca = PCA(n_components=num_dims,
+                    random_state=self.random_state_)
+          if self.verbose:
+            print('Finding principal components... ', end='')
+            sys.stdout.flush()
+          pca.fit(X)
+          transformation = pca.components_
+        elif init == 'lda':
+          from sklearn.discriminant_analysis import (
+            LinearDiscriminantAnalysis)
+          lda = LinearDiscriminantAnalysis(n_components=n_components)
+          if self.verbose:
+            print('Finding most discriminative components... ',
+                  end='')
+            sys.stdout.flush()
+          lda.fit(X, y)
+          transformation = lda.scalings_.T[:n_components]
+        if self.verbose:
+          print('done in {:5.2f}s'.format(time.time() - init_time))
+    return transformation

--- a/metric_learn/nca.py
+++ b/metric_learn/nca.py
@@ -104,11 +104,11 @@ class NCA(BaseMetricLearner):
 
     # Compute loss
     masked_p_ij = p_ij * mask
-    p = np.sum(masked_p_ij, axis=1, keepdims=True)  # (n_samples, 1)
-    loss = np.sum(p)
+    p = masked_p_ij.sum(axis=1, keepdims=True)  # (n_samples, 1)
+    loss = p.sum()
 
     # Compute gradient of loss w.r.t. `transform`
     weighted_p_ij = masked_p_ij - p_ij * p
     gradient = 2 * (X_embedded.T.dot(weighted_p_ij + weighted_p_ij.T) -
-                    X_embedded.T * np.sum(weighted_p_ij, axis=0)).dot(X)
+                    X_embedded.T * weighted_p_ij.sum(axis=0)).dot(X)
     return sign * loss, sign * gradient.ravel()

--- a/metric_learn/nca.py
+++ b/metric_learn/nca.py
@@ -26,11 +26,10 @@ EPS = np.finfo(float).eps
 
 class NCA(BaseMetricLearner):
   def __init__(self, num_dims=None, max_iter=100, learning_rate='deprecated',
-               init='auto', random_state=0, tol=None):
+               random_state=0, tol=None):
     self.num_dims = num_dims
     self.max_iter = max_iter
     self.learning_rate = learning_rate  # TODO: remove in v.0.5.0
-    self.init = init
     self.random_state = random_state
     self.tol = tol
 

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -7,10 +7,9 @@ from sklearn.datasets import load_iris, make_classification
 from numpy.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_warns_message
 
-from metric_learn import (
-    LMNN, NCA, LFDA, Covariance, MLKR, MMC,
-    LSML_Supervised, ITML_Supervised, SDML_Supervised, RCA_Supervised, MMC_Supervised)
-# Import this specially for testing.
+from metric_learn import (LMNN, NCA, LFDA, Covariance, MLKR, MMC,
+                          LSML_Supervised, ITML_Supervised, SDML_Supervised,
+                          RCA_Supervised, MMC_Supervised)
 from metric_learn.lmnn import python_LMNN
 
 
@@ -96,7 +95,7 @@ class TestNCA(MetricTestCase):
     self.assertLess(csep, 0.15)
 
     # With dimension reduction
-    nca = NCA(max_iter=(100000//n), num_dims=2)
+    nca = NCA(max_iter=(100000//n), num_dims=2, tol=1e-9)
     nca.fit(self.iris_points, self.iris_labels)
     csep = class_separation(nca.transform(), self.iris_labels)
     self.assertLess(csep, 0.15)

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -1,9 +1,11 @@
 import unittest
 import numpy as np
+from scipy.optimize import check_grad
 from six.moves import xrange
 from sklearn.metrics import pairwise_distances
-from sklearn.datasets import load_iris
+from sklearn.datasets import load_iris, make_classification
 from numpy.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_warns_message
 
 from metric_learn import (
     LMNN, NCA, LFDA, Covariance, MLKR, MMC,
@@ -88,21 +90,64 @@ class TestNCA(MetricTestCase):
     n = self.iris_points.shape[0]
 
     # Without dimension reduction
-    nca = NCA(max_iter=(100000//n), learning_rate=0.01)
-    nca.fit(self.iris_points, self.iris_labels)
-    # Result copied from Iris example at
-    # https://github.com/vomjom/nca/blob/master/README.mkd
-    expected = [[-0.09935, -0.2215,  0.3383,  0.443],
-                [+0.2532,   0.5835, -0.8461, -0.8915],
-                [-0.729,   -0.6386,  1.767,   1.832],
-                [-0.9405,  -0.8461,  2.281,   2.794]]
-    assert_array_almost_equal(expected, nca.transformer(), decimal=3)
-
-    # With dimension reduction
-    nca = NCA(max_iter=(100000//n), learning_rate=0.01, num_dims=2)
+    nca = NCA(max_iter=(100000//n))
     nca.fit(self.iris_points, self.iris_labels)
     csep = class_separation(nca.transform(), self.iris_labels)
     self.assertLess(csep, 0.15)
+
+    # With dimension reduction
+    nca = NCA(max_iter=(100000//n), num_dims=2)
+    nca.fit(self.iris_points, self.iris_labels)
+    csep = class_separation(nca.transform(), self.iris_labels)
+    self.assertLess(csep, 0.15)
+
+  def test_finite_differences(self):
+    """Test gradient of loss function
+
+    Assert that the gradient is almost equal to its finite differences
+    approximation.
+    """
+    # Initialize the transformation `M`, as well as `X` and `y` and `NCA`
+    X, y = make_classification()
+    M = np.random.randn(np.random.randint(1, X.shape[1] + 1), X.shape[1])
+    mask = y[:, np.newaxis] == y[np.newaxis, :]
+
+    def fun(M):
+      return NCA._loss_grad_lbfgs(M, X, mask)[0]
+
+    def grad(M):
+      return NCA._loss_grad_lbfgs(M, X, mask)[1].ravel()
+
+    # compute relative error
+    rel_diff = check_grad(fun, grad, M.ravel()) / np.linalg.norm(grad(M))
+    np.testing.assert_almost_equal(rel_diff, 0., decimal=6)
+
+  def test_simple_example(self):
+    """Test on a simple example.
+
+    Puts four points in the input space where the opposite labels points are
+    next to each other. After transform the same labels points should be next
+    to each other.
+
+    """
+    X = np.array([[0, 0], [0, 1], [2, 0], [2, 1]])
+    y = np.array([1, 0, 1, 0])
+    nca = NCA(num_dims=2,)
+    nca.fit(X, y)
+    Xansformed = nca.transform(X)
+    np.testing.assert_equal(pairwise_distances(Xansformed).argsort()[:, 1],
+                            np.array([2, 3, 0, 1]))
+
+  def test_deprecation(self):
+    # test that the right deprecation message is thrown.
+    # TODO: remove in v.0.5
+    X = np.array([[0, 0], [0, 1], [2, 0], [2, 1]])
+    y = np.array([1, 0, 1, 0])
+    nca = NCA(num_dims=2, learning_rate=0.01)
+    msg = ('"learning_rate" parameter is not used.'
+           ' It has been deprecated in version 0.4 and will be'
+           'removed in 0.5')
+    assert_warns_message(DeprecationWarning, msg, nca.fit, X, y)
 
 
 class TestLFDA(MetricTestCase):

--- a/test/test_base_metric.py
+++ b/test/test_base_metric.py
@@ -17,7 +17,7 @@ class TestStringRepr(unittest.TestCase):
   def test_nca(self):
     self.assertEqual(str(metric_learn.NCA()),
                      ("NCA(learning_rate='deprecated', max_iter=100, "
-                      "num_dims=None, random_state=0,\n  tol=None)"))
+                      "num_dims=None, tol=None)"))
 
   def test_lfda(self):
     self.assertEqual(str(metric_learn.LFDA()),

--- a/test/test_base_metric.py
+++ b/test/test_base_metric.py
@@ -16,9 +16,8 @@ class TestStringRepr(unittest.TestCase):
 
   def test_nca(self):
     self.assertEqual(str(metric_learn.NCA()),
-                     ("NCA(init='auto', learning_rate='deprecated', "
-                      "max_iter=100, num_dims=None,\n  random_state=0, "
-                      "tol=None)"))
+                     ("NCA(learning_rate='deprecated', max_iter=100, "
+                      "num_dims=None, random_state=0,\n  tol=None)"))
 
   def test_lfda(self):
     self.assertEqual(str(metric_learn.LFDA()),

--- a/test/test_base_metric.py
+++ b/test/test_base_metric.py
@@ -16,7 +16,9 @@ class TestStringRepr(unittest.TestCase):
 
   def test_nca(self):
     self.assertEqual(str(metric_learn.NCA()),
-                     "NCA(learning_rate=0.01, max_iter=100, num_dims=None)")
+                     ("NCA(init='auto', learning_rate='deprecated', "
+                      "max_iter=100, num_dims=None,\n  random_state=0, "
+                      "tol=None)"))
 
   def test_lfda(self):
     self.assertEqual(str(metric_learn.LFDA()),


### PR DESCRIPTION
Fixes #45 
This PR adds a more memory efficient implementation of the gradient of NCA, avoiding creation of a (n, n, d, d) matrix. This is taken from a PR I opened in scikit-learn: https://github.com/scikit-learn/scikit-learn/pull/10058
Eventually, some others improvements of this PR (like verbose, checkers, choice of initializations) would be integrated in metric-learn, but I think for now just changing the gradient computation is fine to solve #45.

Here is a little snippet to show the performance gain: 

```python
from time import time
from sklearn.datasets import load_iris, load_digits
from metric_learn import NCA
for dataset in [load_iris(), load_digits()]:
	X, y = dataset.data, dataset.target
	nca = NCA()
	start = time()
	nca.fit(X, y)
	print(time() - start)
```
Prints for this PR: 
0.1164708137512207  (for iris)
21.722617626190186 (for digits)

Prints for master:
0.9377930164337158  (for iris)
Memory Error (for digits)

Note: with an identity initialization, it prints: 
0.10440230369567871  (for iris)
8.215924263000488 (for digits)
Therefore in this case the init is quite important to help the algorithm converge (identity seems a good init in this case)