### PR TITLE
[MRG] FIX: use addition for starting while loop and checks NaN

### DIFF
--- a/metric_learn/mmc.py
+++ b/metric_learn/mmc.py
@@ -20,7 +20,7 @@ from __future__ import print_function, absolute_import, division
 import numpy as np
 from six.moves import xrange
 from sklearn.metrics import pairwise_distances
-from sklearn.utils.validation import check_array, check_X_y
+from sklearn.utils.validation import check_array, check_X_y, assert_all_finite
 
 from .base_metric import BaseMetricLearner
 from .constraints import Constraints
@@ -261,9 +261,9 @@ class MMC(BaseMetricLearner):
       # search over optimal lambda
       lambd = 1  # initial step-size
       w_tmp = np.maximum(0, w - lambd * step)
-
       obj = np.dot(s_sum, w_tmp) + self.diagonal_c * self._D_objective(X, c, d, w_tmp)
-      obj_previous = obj * 1.1  # just to get the while-loop started
+      assert_all_finite(obj)
+      obj_previous = obj + 1.1  # just to get the while-loop started
 
       inner_it = 0
       while obj < obj_previous:
@@ -273,6 +273,7 @@ class MMC(BaseMetricLearner):
         w_tmp = np.maximum(0, w - lambd * step)
         obj = np.dot(s_sum, w_tmp) + self.diagonal_c * self._D_objective(X, c, d, w_tmp)
         inner_it += 1
+        assert_all_finite(obj)
 
       w[:] = w_previous
       error = np.abs((obj_previous - obj_initial) / obj_previous)

--- a/metric_learn/mmc.py
+++ b/metric_learn/mmc.py
@@ -263,7 +263,7 @@ class MMC(BaseMetricLearner):
       w_tmp = np.maximum(0, w - lambd * step)
       obj = np.dot(s_sum, w_tmp) + self.diagonal_c * self._D_objective(X, c, d, w_tmp)
       assert_all_finite(obj)
-      obj_previous = obj + 1.1  # just to get the while-loop started
+      obj_previous = obj + 1  # just to get the while-loop started
 
       inner_it = 0
       while obj < obj_previous:


### PR DESCRIPTION
Fixes #74: uses addition rather than multiplication for getting the while loop started, and throw error when NaN are found