### PR TITLE
[WIP] Add verbose to NCA and MLKR

### DIFF
--- a/metric_learn/mlkr.py
+++ b/metric_learn/mlkr.py
@@ -7,11 +7,15 @@ algorithm can also be viewed as a supervised variation of PCA and can be used
 for dimensionality reduction and high dimensional data visualization.
 """
 from __future__ import division, print_function
+import time
+import sys
+import warnings
 import numpy as np
 from scipy.optimize import minimize
 from scipy.spatial.distance import pdist, squareform
 from sklearn.decomposition import PCA
 from sklearn.utils.validation import check_X_y
+from sklearn.exceptions import ConvergenceWarning
 
 from .base_metric import BaseMetricLearner
 
@@ -21,7 +25,7 @@ EPS = np.finfo(float).eps
 class MLKR(BaseMetricLearner):
   """Metric Learning for Kernel Regression (MLKR)"""
   def __init__(self, num_dims=None, A0=None, epsilon=0.01, alpha=0.0001,
-               max_iter=1000):
+               max_iter=1000, verbose=False):
     """
     Initialize MLKR.
 
@@ -41,12 +45,16 @@ class MLKR(BaseMetricLearner):
 
     max_iter: int, optional
         Cap on number of congugate gradient iterations.
+
+    verbose : bool, optional (default=False)
+        Whether to print progress messages or not.
     """
     self.num_dims = num_dims
     self.A0 = A0
     self.epsilon = epsilon
     self.alpha = alpha
     self.max_iter = max_iter
+    self.verbose = verbose
 
   def _process_inputs(self, X, y):
       self.X_, y = check_X_y(X, y)
@@ -79,34 +87,69 @@ class MLKR(BaseMetricLearner):
       """
       X, y, A = self._process_inputs(X, y)
 
+      # Measure the total training time
+      t_train = time.time()
+
       # note: this line takes (n*n*d) memory!
       # for larger datasets, we'll need to compute dX as we go
       dX = (X[None] - X[:, None]).reshape((-1, X.shape[1]))
 
-      res = minimize(_loss, A.ravel(), (X, y, dX), method='CG', jac=True,
+      self.n_iter_ = 0
+      res = minimize(self._loss, A.ravel(), (X, y, dX), method='CG', jac=True,
                      tol=self.alpha,
                      options=dict(maxiter=self.max_iter, eps=self.epsilon))
       self.transformer_ = res.x.reshape(A.shape)
-      self.n_iter_ = res.nit
+
+      if self.verbose:
+          cls_name = self.__class__.__name__
+          # Warn the user if the algorithm did not converge
+          if not res.success:
+              warnings.warn('[{}] MLKR did not converge: {}'
+                            .format(cls_name, res.message), ConvergenceWarning)
+          print('[{}] Training took {:8.2f}s.'.format(cls_name, t_train))
+
+      self.n_iter_ += 1
       return self
 
   def transformer(self):
       return self.transformer_
 
+  def _loss(self, flatA, X, y, dX):
 
-def _loss(flatA, X, y, dX):
-  A = flatA.reshape((-1, X.shape[1]))
-  dist = pdist(X, metric='mahalanobis', VI=A.T.dot(A))
-  K = squareform(np.exp(-dist**2))
-  denom = np.maximum(K.sum(axis=0), EPS)
-  yhat = K.dot(y) / denom
-  ydiff = yhat - y
-  cost = (ydiff**2).sum()
+    if self.n_iter_ == 0:
+      if self.verbose:
+        header_fields = ['Iteration', 'Objective Value', 'Time(s)']
+        header_fmt = '{:>10} {:>20} {:>10}'
+        header = header_fmt.format(*header_fields)
+        cls_name = self.__class__.__name__
+        print('[{}]'.format(cls_name))
+        print('[{}] {}\n[{}] {}'.format(cls_name, header, cls_name,
+                                        '-' * len(header)))
 
-  # also compute the gradient
-  np.fill_diagonal(K, 1)
-  W = 2 * K * (np.outer(ydiff, ydiff) / denom)
-  # note: this is the part that the matlab impl drops to C for
-  M = (dX.T * W.ravel()).dot(dX)
-  grad = 2 * A.dot(M)
-  return cost, grad.ravel()
+    t_funcall = time.time()
+
+    A = flatA.reshape((-1, X.shape[1]))
+    dist = pdist(X, metric='mahalanobis', VI=A.T.dot(A))
+    K = squareform(np.exp(-dist**2))
+    denom = np.maximum(K.sum(axis=0), EPS)
+    yhat = K.dot(y) / denom
+    ydiff = yhat - y
+    cost = (ydiff**2).sum()
+
+    # also compute the gradient
+    np.fill_diagonal(K, 1)
+    W = 2 * K * (np.outer(ydiff, ydiff) / denom)
+    # note: this is the part that the matlab impl drops to C for
+    M = (dX.T * W.ravel()).dot(dX)
+    grad = 2 * A.dot(M)
+
+    if self.verbose:
+      t_funcall = time.time() - t_funcall
+      values_fmt = '[{}] {:>10} {:>20.6e} {:>10.2f}'
+      print(values_fmt.format(self.__class__.__name__, self.n_iter_, cost,
+            t_funcall))
+      sys.stdout.flush()
+
+    self.n_iter_ += 1
+
+    return cost, grad.ravel()

--- a/metric_learn/mlkr.py
+++ b/metric_learn/mlkr.py
@@ -108,7 +108,6 @@ class MLKR(BaseMetricLearner):
                             .format(cls_name, res.message), ConvergenceWarning)
           print('[{}] Training took {:8.2f}s.'.format(cls_name, t_train))
 
-      self.n_iter_ += 1
       return self
 
   def transformer(self):

--- a/metric_learn/nca.py
+++ b/metric_learn/nca.py
@@ -6,10 +6,13 @@ Ported to Python from https://github.com/vomjom/nca
 from __future__ import absolute_import
 
 import warnings
+import time
+import sys
 import numpy as np
 from scipy.optimize import minimize
 from sklearn.metrics import pairwise_distances
 from sklearn.utils.validation import check_X_y
+from sklearn.exceptions import ConvergenceWarning
 
 try:  # scipy.misc.logsumexp is deprecated in scipy 1.0.0
     from scipy.special import logsumexp
@@ -23,7 +26,7 @@ EPS = np.finfo(float).eps
 
 class NCA(BaseMetricLearner):
   def __init__(self, num_dims=None, max_iter=100, learning_rate='deprecated',
-               tol=None):
+               tol=None, verbose=False):
     """Neighborhood Components Analysis
 
     Parameters
@@ -44,11 +47,15 @@ class NCA(BaseMetricLearner):
 
     tol : float, optional (default=None)
         Convergence tolerance for the optimization.
+
+    verbose : bool, optional (default=False)
+      Whether to print progress messages or not.
     """
     self.num_dims = num_dims
     self.max_iter = max_iter
     self.learning_rate = learning_rate  # TODO: remove in v.0.5.0
     self.tol = tol
+    self.verbose = verbose
 
   def transformer(self):
     return self.A_
@@ -69,6 +76,9 @@ class NCA(BaseMetricLearner):
     if num_dims is None:
         num_dims = d
 
+    # Measure the total training time
+    t_train = time.time()
+
     # Initialize A to a scaling matrix
     A = np.zeros((num_dims, d))
     np.fill_diagonal(A, 1./(np.maximum(X.max(axis=0)-X.min(axis=0), EPS)))
@@ -85,15 +95,38 @@ class NCA(BaseMetricLearner):
                         }
 
     # Call the optimizer
+    self.n_iter_ = 0
     opt_result = minimize(**optimizer_params)
 
     self.X_ = X
     self.A_ = opt_result.x.reshape(-1, X.shape[1])
     self.n_iter_ = opt_result.nit
+    if self.verbose:
+      cls_name = self.__class__.__name__
+
+      # Warn the user if the algorithm did not converge
+      if not opt_result.success:
+        warnings.warn('[{}] NCA did not converge: {}'.format(
+            cls_name, opt_result.message), ConvergenceWarning)
+
+      print('[{}] Training took {:8.2f}s.'.format(cls_name, t_train))
+
     return self
 
-  @staticmethod
-  def _loss_grad_lbfgs(A, X, mask, sign=1.0):
+  def _loss_grad_lbfgs(self, A, X, mask, sign=1.0):
+
+    if self.n_iter_ == 0:
+      if self.verbose:
+        header_fields = ['Iteration', 'Objective Value', 'Time(s)']
+        header_fmt = '{:>10} {:>20} {:>10}'
+        header = header_fmt.format(*header_fields)
+        cls_name = self.__class__.__name__
+        print('[{}]'.format(cls_name))
+        print('[{}] {}\n[{}] {}'.format(cls_name, header,
+                                        cls_name, '-' * len(header)))
+
+    t_funcall = time.time()
+
     A = A.reshape(-1, X.shape[1])
     X_embedded = np.dot(X, A.T)  # (n_samples, num_dims)
     # Compute softmax distances
@@ -111,4 +144,14 @@ class NCA(BaseMetricLearner):
     weighted_p_ij = masked_p_ij - p_ij * p
     gradient = 2 * (X_embedded.T.dot(weighted_p_ij + weighted_p_ij.T) -
                     X_embedded.T * weighted_p_ij.sum(axis=0)).dot(X)
+
+    if self.verbose:
+        t_funcall = time.time() - t_funcall
+        values_fmt = '[{}] {:>10} {:>20.6e} {:>10.2f}'
+        print(values_fmt.format(self.__class__.__name__, self.n_iter_,
+                                loss, t_funcall))
+        sys.stdout.flush()
+
+    self.n_iter_ += 1
+
     return sign * loss, sign * gradient.ravel()

--- a/test/test_base_metric.py
+++ b/test/test_base_metric.py
@@ -17,7 +17,7 @@ class TestStringRepr(unittest.TestCase):
   def test_nca(self):
     self.assertEqual(str(metric_learn.NCA()),
                      ("NCA(learning_rate='deprecated', max_iter=100, "
-                      "num_dims=None, tol=None)"))
+                      "num_dims=None, tol=None,\n  verbose=False)"))
 
   def test_lfda(self):
     self.assertEqual(str(metric_learn.LFDA()),

--- a/test/test_base_metric.py
+++ b/test/test_base_metric.py
@@ -62,7 +62,7 @@ SDML_Supervised(balance_param=0.5, num_constraints=None, num_labeled=inf,
   def test_mlkr(self):
     self.assertEqual(str(metric_learn.MLKR()),
                      "MLKR(A0=None, alpha=0.0001, epsilon=0.01, "
-                     "max_iter=1000, num_dims=None)")
+                     "max_iter=1000, num_dims=None,\n   verbose=False)")
 
   def test_mmc(self):
     self.assertEqual(str(metric_learn.MMC()), """


### PR DESCRIPTION
Fixes #67.

This PR adds a verbose argument for `NCA` and `MLKR`. Here is an example on a snippet. 

```python
from sklearn.datasets import load_digits
from metric_learn import NCA
dataset = load_digits()
X, y = dataset.data, dataset.target
nca = NCA(verbose=True, max_iter=5)
nca.fit(X, y)
```
Returns: 

```pytb
[NCA]
[NCA]  Iteration      Objective Value    Time(s)
[NCA] ------------------------------------------
[NCA]          0         1.436318e+03       0.23
[NCA]          1         1.770346e+03       0.24
[NCA]          2         1.777018e+03       0.26
[NCA]          3         1.779409e+03       0.25
[NCA]          4         1.781304e+03       0.26
[NCA]          5         1.782404e+03       0.25
/home/will/Code/metric-learn-bis/metric_learn/nca.py:110: ConvergenceWarning: [NCA] NCA did not converge: b'STOP: TOTAL NO. of ITERATIONS REACHED LIMIT'
  cls_name, opt_result.message), ConvergenceWarning)
[NCA] Training took 1533143523.76s.
```

The code mostly comes from scikit-learn's NCA PR (https://github.com/scikit-learn/scikit-learn/pull/10058), and this verbose code in particular was taken mostly from scikit-learn's LMNN PR (https://github.com/scikit-learn/scikit-learn/pull/8602)

### TODO: 
- [ ] Fix the convergence warning test for `MLKR` (related to #104)