### PR TITLE
[MRG] Update __init__.py to allow printing version

### DIFF
--- a/metric_learn/__init__.py
+++ b/metric_learn/__init__.py
@@ -11,3 +11,5 @@ from .lfda import LFDA
 from .rca import RCA, RCA_Supervised
 from .mlkr import MLKR
 from .mmc import MMC, MMC_Supervised
+
+__version__ = '0.4.0'

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from setuptools import setup
+import metric_learn
 
-version = "0.4.0"
+version = metric_learn.__version__
 setup(name='metric-learn',
       version=version,
       description='Python implementations of metric learning algorithms',


### PR DESCRIPTION
this code should print the version number:

```python
import metric_learn
print(metric_learn.__version__)
```

However it doesn't work. 

This modification allows the version number to be accessed like this.