### PR TITLE
Add version number in __init__.py, new PR

### DIFF
--- a/metric_learn/__init__.py
+++ b/metric_learn/__init__.py
@@ -11,3 +11,7 @@ from .lfda import LFDA
 from .rca import RCA, RCA_Supervised
 from .mlkr import MLKR
 from .mmc import MMC, MMC_Supervised
+
+import pkg_resources
+
+__version__ = pkg_resources.get_distribution("metric-learn").version


### PR DESCRIPTION
This is the new PR to add version number in __init__.py
I saw it from the umap package https://github.com/lmcinnes/umap/tree/master/umap
What do you think ? 
I tried and it seemed to solve the problem in the previous PR (#108)