### PR TITLE
[MRG] Improve gradient computation in NCA and MLKR

### DIFF
--- a/metric_learn/mlkr.py
+++ b/metric_learn/mlkr.py
@@ -13,6 +13,7 @@ from scipy.optimize import minimize
 from scipy.spatial.distance import pdist, squareform
 from sklearn.decomposition import PCA
 from sklearn.utils.validation import check_X_y
+from numpy.linalg import multi_dot
 
 from .base_metric import BaseMetricLearner
 
@@ -102,7 +103,8 @@ def _loss(flatA, X, y):
   cost = (ydiff**2).sum()
 
   # also compute the gradient
-  W = softmax * ydiff[:, np.newaxis] * (yhat[:, np.newaxis] - y)
-  X_emb_t = A.dot(X.T)
-  grad = 4 * (X_emb_t * W.sum(axis=0) - X_emb_t.dot(W + W.T)).dot(X)
+  W = softmax * ydiff[:, np.newaxis] * (y - yhat[:, np.newaxis])
+  W_sym = W + W.T
+  np.fill_diagonal(W_sym, - W.sum(axis=0))
+  grad = 4 * multi_dot([A, X.T, W_sym, X])
   return cost, grad.ravel()

--- a/metric_learn/nca.py
+++ b/metric_learn/nca.py
@@ -112,5 +112,5 @@ class NCA(BaseMetricLearner):
     weighted_p_ij = masked_p_ij - p_ij * p
     weighted_p_ij_sym = weighted_p_ij + weighted_p_ij.T
     np.fill_diagonal(weighted_p_ij_sym, - weighted_p_ij.sum(axis=0))
-    gradient = 2 * multi_dot([A, X.T, weighted_p_ij_sym, X])
+    gradient = 2 * (X_embedded.T.dot(weighted_p_ij_sym)).dot(X)
     return sign * loss, sign * gradient.ravel()

--- a/metric_learn/nca.py
+++ b/metric_learn/nca.py
@@ -10,6 +10,7 @@ import numpy as np
 from scipy.optimize import minimize
 from sklearn.metrics import pairwise_distances
 from sklearn.utils.validation import check_X_y
+from numpy.linalg import multi_dot
 
 try:  # scipy.misc.logsumexp is deprecated in scipy 1.0.0
     from scipy.special import logsumexp
@@ -109,6 +110,7 @@ class NCA(BaseMetricLearner):
 
     # Compute gradient of loss w.r.t. `transform`
     weighted_p_ij = masked_p_ij - p_ij * p
-    gradient = 2 * (X_embedded.T.dot(weighted_p_ij + weighted_p_ij.T) -
-                    X_embedded.T * weighted_p_ij.sum(axis=0)).dot(X)
+    weighted_p_ij_sym = weighted_p_ij + weighted_p_ij.T
+    np.fill_diagonal(weighted_p_ij_sym, - weighted_p_ij.sum(axis=0))
+    gradient = 2 * multi_dot([A, X.T, weighted_p_ij_sym, X])
     return sign * loss, sign * gradient.ravel()


### PR DESCRIPTION
Uses [np.linalg.multi_dot](https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.multi_dot.html) in gradient computations in `NCA` and `MLKR`. This should provide optimal performance, no matter the values of `n_components`, `n_features`, and `n_samples`.