### PR TITLE
[MRG] FIX: add long_description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,14 @@ version = {}
 with open(os.path.join('metric_learn', '_version.py')) as fp:
   exec(fp.read(), version)
 
+# Get the long description from README.md
+with open('README.rst', encoding='utf-8') as f:
+  long_description = f.read()
+
 setup(name='metric-learn',
       version=version['__version__'],
       description='Python implementations of metric learning algorithms',
+      long_description=long_description,
       author=['CJ Carey', 'Yuan Tang'],
       author_email='ccarey@cs.umass.edu',
       url='http://github.com/all-umass/metric-learn',


### PR DESCRIPTION
This adds the long description to setup.py to allow the README to be displayed on PyPI with the new changes in PyPI (see comment https://github.com/metric-learn/metric-learn/issues/71#issuecomment-418767379)