### PR TITLE
Fix python2.7 compatibility in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,14 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
 import os
+import io
 
 version = {}
-with open(os.path.join('metric_learn', '_version.py')) as fp:
+with io.open(os.path.join('metric_learn', '_version.py')) as fp:
   exec(fp.read(), version)
 
 # Get the long description from README.md
-with open('README.rst', encoding='utf-8') as f:
+with io.open('README.rst', encoding='utf-8') as f:
   long_description = f.read()
 
 setup(name='metric-learn',


### PR DESCRIPTION
Got the following when running tests under python2.7:
```
Traceback (most recent call last):
  File "setup.py", line 11, in <module>
    with open('README.rst', encoding='utf-8') as f:
TypeError: 'encoding' is an invalid keyword argument for this function
```
Reference: https://stackoverflow.com/questions/25049962/is-encoding-is-an-invalid-keyword-error-inevitable-in-python-2-x