### PR TITLE
[MRG] Quick fix of failed tests due to new scikit-learn version (0.20.0)

### DIFF
--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -191,7 +191,7 @@ class ITML_Supervised(ITML):
     random_state : numpy.random.RandomState, optional
         If provided, controls random number generation.
     """
-    X, y = check_X_y(X, y)
+    X, y = check_X_y(X, y, ensure_min_samples=2)
     num_constraints = self.num_constraints
     if num_constraints is None:
       num_classes = len(np.unique(y))

--- a/metric_learn/lmnn.py
+++ b/metric_learn/lmnn.py
@@ -52,7 +52,7 @@ class _base_LMNN(BaseMetricLearner):
 class python_LMNN(_base_LMNN):
 
   def _process_inputs(self, X, labels):
-    self.X_ = check_array(X, dtype=float)
+    self.X_ = check_array(X, dtype=float, ensure_min_samples=2)
     num_pts, num_dims = self.X_.shape
     unique_labels, self.label_inds_ = np.unique(labels, return_inverse=True)
     if len(self.label_inds_) != num_pts:

--- a/metric_learn/lsml.py
+++ b/metric_learn/lsml.py
@@ -178,7 +178,7 @@ class LSML_Supervised(LSML):
     random_state : numpy.random.RandomState, optional
         If provided, controls random number generation.
     """
-    X, y = check_X_y(X, y)
+    X, y = check_X_y(X, y, ensure_min_samples=2)
     num_constraints = self.num_constraints
     if num_constraints is None:
       num_classes = len(np.unique(y))

--- a/metric_learn/mmc.py
+++ b/metric_learn/mmc.py
@@ -434,7 +434,7 @@ class MMC_Supervised(MMC):
     random_state : numpy.random.RandomState, optional
         If provided, controls random number generation.
     """
-    X, y = check_X_y(X, y)
+    X, y = check_X_y(X, y, ensure_min_samples=2)
     num_constraints = self.num_constraints
     if num_constraints is None:
       num_classes = len(np.unique(y))

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -133,7 +133,7 @@ class TestNCA(MetricTestCase):
     nca = NCA(max_iter=(100000//n), num_dims=2, tol=1e-9)
     nca.fit(self.iris_points, self.iris_labels)
     csep = class_separation(nca.transform(), self.iris_labels)
-    self.assertLess(csep, 0.15)
+    self.assertLess(csep, 0.20)
 
   def test_finite_differences(self):
     """Test gradient of loss function
@@ -319,16 +319,17 @@ class TestMMC(MetricTestCase):
     # Full metric
     mmc = MMC(convergence_threshold=0.01)
     mmc.fit(self.iris_points, [a,b,c,d])
-    expected = [[+0.00046504, +0.00083371, -0.00111959, -0.00165265],
-                [+0.00083371, +0.00149466, -0.00200719, -0.00296284],
-                [-0.00111959, -0.00200719, +0.00269546, +0.00397881],
-                [-0.00165265, -0.00296284, +0.00397881, +0.00587320]]
+    expected = [[0.000465,  0.000834, -0.00112, -0.001653],
+                [0.000834, 0.001495, -0.002007, -0.002963],
+                [-0.00112, -0.002007,  0.002695,  0.003979],
+                [-0.001653, -0.002963,  0.003979,  0.005873]]
     assert_array_almost_equal(expected, mmc.metric(), decimal=6)
 
     # Diagonal metric
     mmc = MMC(diagonal=True)
     mmc.fit(self.iris_points, [a,b,c,d])
-    expected = [0, 0, 1.21045968, 1.22552608]
+    expected = [0, 0, 1.210460, 1.225526]
+
     assert_array_almost_equal(np.diag(expected), mmc.metric(), decimal=6)
     
     # Supervised Full

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -44,7 +44,7 @@ class TestCovariance(MetricTestCase):
 
     csep = class_separation(cov.transform(), self.iris_labels)
     # deterministic result
-    self.assertAlmostEqual(csep, 0.73068122)
+    self.assertAlmostEqual(csep, 0.72981476)
 
 
 class TestLSML(MetricTestCase):
@@ -319,16 +319,16 @@ class TestMMC(MetricTestCase):
     # Full metric
     mmc = MMC(convergence_threshold=0.01)
     mmc.fit(self.iris_points, [a,b,c,d])
-    expected = [[0.000465,  0.000834, -0.00112, -0.001653],
-                [0.000834, 0.001495, -0.002007, -0.002963],
-                [-0.00112, -0.002007,  0.002695,  0.003979],
-                [-0.001653, -0.002963,  0.003979,  0.005873]]
+    expected = [[ 0.000514,  0.000868, -0.001195, -0.001703],
+                [ 0.000868,  0.001468, -0.002021, -0.002879],
+                [-0.001195, -0.002021,  0.002782,  0.003964],
+                [-0.001703, -0.002879,  0.003964,  0.005648]]
     assert_array_almost_equal(expected, mmc.metric(), decimal=6)
 
     # Diagonal metric
     mmc = MMC(diagonal=True)
     mmc.fit(self.iris_points, [a,b,c,d])
-    expected = [0, 0, 1.210460, 1.225526]
+    expected = [0, 0, 1.210220, 1.228596]
 
     assert_array_almost_equal(np.diag(expected), mmc.metric(), decimal=6)
     


### PR DESCRIPTION
Fixes #126 #127 

This is a quick fix that fixes #126 and #127, by setting `ensure_min_samples=2` in checks of the inputs to pass scikit-learn's check_estimator test (see #127), and by updating the scores with the new values for the iris dataset.

But I opened two issues that tackle solving these problems in the long term (cf #127)
- issue #128 to decide what is the minimal number of samples that we want to allow the "fit" method on 
- issue #129 to deal with tests that test some hard values