### PR TITLE
[MRG] Fix: SDML on sandwich example

### DIFF
--- a/examples/plot_sandwich.py
+++ b/examples/plot_sandwich.py
@@ -28,7 +28,7 @@ def sandwich_demo():
   mls = [
       LMNN(),
       ITML_Supervised(num_constraints=200),
-      SDML_Supervised(num_constraints=200),
+      SDML_Supervised(num_constraints=200, balance_param=0.001),
       LSML_Supervised(num_constraints=200),
   ]
 


### PR DESCRIPTION
Fixes #138 

Thanks to #162 we can now make SDML work on the sandwich example by reducing `balance_param` (see figure)

![sandwich](https://user-images.githubusercontent.com/7905665/55003087-f9dbb800-4fd7-11e9-851c-baf74e7e8daf.png)
