### PR TITLE
[MRG] make transformer_from_metric more robust

### DIFF
--- a/test/test_transformer_metric_conversion.py
+++ b/test/test_transformer_metric_conversion.py
@@ -1,11 +1,15 @@
 import unittest
 import numpy as np
+import pytest
+from scipy.stats import ortho_group
 from sklearn.datasets import load_iris
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_allclose
+from sklearn.utils.testing import ignore_warnings
 
 from metric_learn import (
     LMNN, NCA, LFDA, Covariance, MLKR,
     LSML_Supervised, ITML_Supervised, SDML_Supervised, RCA_Supervised)
+from metric_learn._util import transformer_from_metric
 
 
 class TestTransformerMetricConversion(unittest.TestCase):
@@ -75,6 +79,84 @@ class TestTransformerMetricConversion(unittest.TestCase):
     mlkr.fit(self.X, self.y)
     L = mlkr.transformer_
     assert_array_almost_equal(L.T.dot(L), mlkr.get_mahalanobis_matrix())
+
+  @ignore_warnings
+  def test_transformer_from_metric_edge_cases(self):
+    """Test that transformer_from_metric returns the right result in various
+    edge cases"""
+    rng = np.random.RandomState(42)
+
+    # an orthonormal matrix useful for creating matrices with given
+    # eigenvalues:
+    P = ortho_group.rvs(7, random_state=rng)
+
+    # matrix with all its coefficients very low (to check that the algorithm
+    # does not consider it as a diagonal matrix)(non regression test for
+    # https://github.com/metric-learn/metric-learn/issues/175)
+    M = np.diag([1e-15, 2e-16, 3e-15, 4e-16, 5e-15, 6e-16, 7e-15])
+    M = P.dot(M).dot(P.T)
+    L = transformer_from_metric(M)
+    assert_allclose(L.T.dot(L), M)
+
+    # diagonal matrix
+    M = np.diag(np.abs(rng.randn(5)))
+    L = transformer_from_metric(M)
+    assert_allclose(L.T.dot(L), M)
+
+    # low-rank matrix (with zeros)
+    M = np.zeros((7, 7))
+    small_random = rng.randn(3, 3)
+    M[:3, :3] = small_random.T.dot(small_random)
+    L = transformer_from_metric(M)
+    assert_allclose(L.T.dot(L), M)
+
+    # low-rank matrix (without necessarily zeros)
+    R = np.abs(rng.randn(7, 7))
+    M = R.dot(np.diag([1, 5, 3, 2, 0, 0, 0])).dot(R.T)
+    L = transformer_from_metric(M)
+    assert_allclose(L.T.dot(L), M)
+
+    # matrix with a determinant still high but which should be considered as a
+    # non-definite matrix
+    M = np.diag([1e5, 1e5, 1e5, 1e5, 1e5, 1e5, 1e-10])
+    M = P.dot(M).dot(P.T)
+    L = transformer_from_metric(M)
+    assert_allclose(L.T.dot(L), M)
+
+    # matrix with lots of small nonzeros that make a big zero when multiplied
+    M = np.diag([1e-3, 1e-3, 1e-3, 1e-3, 1e-3, 1e-3, 1e-3])
+    L = transformer_from_metric(M)
+    assert_allclose(L.T.dot(L), M)
+
+    # full rank matrix
+    M = rng.randn(10, 10)
+    M = M.T.dot(M)
+    assert np.linalg.matrix_rank(M) == 10
+    L = transformer_from_metric(M)
+    assert_allclose(L.T.dot(L), M)
+
+  def test_non_symmetric_matrix_raises(self):
+    """Checks that if a non symmetric matrix is given to
+    transformer_from_metric, an error is thrown"""
+    rng = np.random.RandomState(42)
+    M = rng.randn(10, 10)
+    with pytest.raises(ValueError) as raised_error:
+      transformer_from_metric(M)
+    assert str(raised_error.value) == "The input metric should be symmetric."
+
+  def test_non_psd_warns(self):
+    """Checks that if the matrix is not PSD it will raise a warning saying
+    that we will do the eigendecomposition"""
+    rng = np.random.RandomState(42)
+    R = np.abs(rng.randn(7, 7))
+    M = R.dot(np.diag([1, 5, 3, 2, 0, 0, 0])).dot(R.T)
+    msg = ("The Cholesky decomposition returned the following "
+           "error: 'Matrix is not positive definite'. Using the "
+           "eigendecomposition instead.")
+    with pytest.warns(None) as raised_warning:
+      L = transformer_from_metric(M)
+    assert str(raised_warning[0].message) == msg
+    assert_allclose(L.T.dot(L), M)
 
 
 if __name__ == '__main__':

--- a/test/test_transformer_metric_conversion.py
+++ b/test/test_transformer_metric_conversion.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy as np
 import pytest
+from numpy.linalg import LinAlgError
 from scipy.stats import ortho_group
 from sklearn.datasets import load_iris
 from numpy.testing import assert_array_almost_equal, assert_allclose
@@ -117,9 +118,18 @@ class TestTransformerMetricConversion(unittest.TestCase):
     assert_allclose(L.T.dot(L), M)
 
     # matrix with a determinant still high but which should be considered as a
-    # non-definite matrix
-    M = np.diag([1e5, 1e5, 1e5, 1e5, 1e5, 1e5, 1e-10])
+    # non-definite matrix (to check we don't test the definiteness with the
+    # determinant which is a bad strategy)
+    M = np.diag([1e5, 1e5, 1e5, 1e5, 1e5, 1e5, 1e-20])
     M = P.dot(M).dot(P.T)
+    assert np.abs(np.linalg.det(M)) > 10
+    assert np.linalg.slogdet(M) > 1  # (just to show that the computed
+    # determinant is far from null)
+    with pytest.raises(LinAlgError) as err_msg:
+      np.linalg.cholesky(M)
+    assert str(err_msg.value) == 'Matrix is not positive definite'
+    # (just to show that this case is indeed considered by numpy as an
+    # indefinite case)
     L = transformer_from_metric(M)
     assert_allclose(L.T.dot(L), M)
 

--- a/test/test_transformer_metric_conversion.py
+++ b/test/test_transformer_metric_conversion.py
@@ -161,9 +161,12 @@ class TestTransformerMetricConversion(unittest.TestCase):
     D = np.diag([1, 5, 3, 4.2, -4, -2, 1])
     P = ortho_group.rvs(7, random_state=rng)
     M = P.dot(D).dot(P.T)
+    msg = ("Matrix is not positive semidefinite (PSD).")
     with pytest.raises(ValueError) as raised_error:
       transformer_from_metric(M)
-    msg = ("Matrix is not positive semidefinite (PSD).")
+    assert str(raised_error.value) == msg
+    with pytest.raises(ValueError) as raised_error:
+      transformer_from_metric(D)
     assert str(raised_error.value) == msg
 
   def test_almost_psd_dont_raise(self):

--- a/test/test_transformer_metric_conversion.py
+++ b/test/test_transformer_metric_conversion.py
@@ -123,7 +123,7 @@ class TestTransformerMetricConversion(unittest.TestCase):
     M = np.diag([1e5, 1e5, 1e5, 1e5, 1e5, 1e5, 1e-20])
     M = P.dot(M).dot(P.T)
     assert np.abs(np.linalg.det(M)) > 10
-    assert np.linalg.slogdet(M) > 1  # (just to show that the computed
+    assert np.linalg.slogdet(M)[1] > 1  # (just to show that the computed
     # determinant is far from null)
     with pytest.raises(LinAlgError) as err_msg:
       np.linalg.cholesky(M)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -9,7 +9,8 @@ from sklearn.utils.testing import set_random_state
 from sklearn.base import clone
 from metric_learn._util import (check_input, make_context, preprocess_tuples,
                                 make_name, preprocess_points,
-                                check_collapsed_pairs, validate_vector)
+                                check_collapsed_pairs, validate_vector,
+                                _check_sdp_from_eigen)
 from metric_learn import (ITML, LSML, MMC, RCA, SDML, Covariance, LFDA,
                           LMNN, MLKR, NCA, ITML_Supervised, LSML_Supervised,
                           MMC_Supervised, RCA_Supervised, SDML_Supervised,
@@ -1030,3 +1031,21 @@ def test__validate_vector():
   x = [[1, 2], [3, 4]]
   with pytest.raises(ValueError):
     validate_vector(x)
+
+
+def _check_sdp_from_eigen_positive_err_messages():
+  """Tests that if _check_sdp_from_eigen is given a negative tol it returns
+  an error, and if positive it does not"""
+  w = np.random.RandomState(42).randn(10)
+  with pytest.raises(ValueError) as raised_error:
+    _check_sdp_from_eigen(w, -5.)
+  assert str(raised_error.value) == "tol should be positive."
+  with pytest.raises(ValueError) as raised_error:
+    _check_sdp_from_eigen(w, -1e-10)
+  assert str(raised_error.value) == "tol should be positive."
+  with pytest.raises(ValueError) as raised_error:
+    _check_sdp_from_eigen(w, 1.)
+  assert len(raised_error.value) == 0
+  with pytest.raises(ValueError) as raised_error:
+    _check_sdp_from_eigen(w, 0.)
+  assert str(raised_error.value) == 0


### PR DESCRIPTION
Fixes #175 

This PR fixes the problem we had with `transformer_from_metric`, by checking if the matrix is diagonal depending on the relative gap between the maximum absolute value of the outer diagonal coeffs, and the minimum absolute value of the diagonal coefficients, rather than what was done before.

It is also more robust for detecting whether to use Cholesky or the eigendecomposition: instead of computing the determinant to check if the matrix is not definite, it tries to do Cholesky and if an error is returned it does the eigendecomposition. Indeed, maybe the determinant can be not null if there is a very small eigenvalue (`v`=1e-5) (that should be considered as null), but a lot of big eigenvalues (see one example in the test)

It also raises an error message when the input is not symmetric and a warning when switching from the Cholesky decomposition to the eigendecompostion if the Cholesky decomposition is not doable.


TODO:
- [x] to make a good test, check the value of `v` for which cholesky will fail, and from it build the example where the determinant is not "np.close" to zero 