### PR TITLE
[MRG] Fix RCA_Supervised sklearn compat test

### DIFF
--- a/metric_learn/rca.py
+++ b/metric_learn/rca.py
@@ -30,7 +30,7 @@ def _chunk_mean_centering(data, chunks):
   # through slices hence we do a copy. We will also need to
   # ensure the data is float so that we can substract the
   # mean on it
-  chunk_data = data[chunk_mask].astype(float, copy=True)
+  chunk_data = data[chunk_mask].astype(float, copy=False)
   chunk_labels = chunks[chunk_mask]
   for c in xrange(num_chunks):
     mask = chunk_labels == c

--- a/metric_learn/rca.py
+++ b/metric_learn/rca.py
@@ -26,9 +26,7 @@ from .constraints import Constraints
 def _chunk_mean_centering(data, chunks):
   num_chunks = chunks.max() + 1
   chunk_mask = chunks != -1
-  # Warning: we need to ensure we don't overwrite the data
-  # through slices hence we do a copy. We will also need to
-  # ensure the data is float so that we can substract the
+  # We need to ensure the data is float so that we can substract the
   # mean on it
   chunk_data = data[chunk_mask].astype(float, copy=False)
   chunk_labels = chunks[chunk_mask]

--- a/test/test_sklearn_compat.py
+++ b/test/test_sklearn_compat.py
@@ -93,7 +93,9 @@ class TestSklearnCompat(unittest.TestCase):
     def stable_init(self, num_dims=None, pca_comps=None,
                     chunk_size=2, preprocessor=None):
       # this init makes RCA stable for scikit-learn examples.
-      RCA_Supervised.__init__(self, num_chunks=2)
+      RCA_Supervised.__init__(self, num_chunks=2, num_dims=num_dims,
+                              pca_comps=pca_comps, chunk_size=chunk_size,
+                              preprocessor=preprocessor)
     dRCA.__init__ = stable_init
     check_estimator(dRCA)
 

--- a/test/test_sklearn_compat.py
+++ b/test/test_sklearn_compat.py
@@ -89,9 +89,13 @@ class TestSklearnCompat(unittest.TestCase):
     dSDML.__init__ = stable_init
     check_estimator(dSDML)
 
-  # This fails because the default num_chunks isn't data-dependent.
-  # def test_rca(self):
-  #   check_estimator(RCA_Supervised)
+  def test_rca(self):
+    def stable_init(self, num_dims=None, pca_comps=None,
+                    chunk_size=2, preprocessor=None):
+      # this init makes RCA stable for scikit-learn examples.
+      RCA_Supervised.__init__(self, num_chunks=2)
+    dRCA.__init__ = stable_init
+    check_estimator(dRCA)
 
 
 RNG = check_random_state(0)


### PR DESCRIPTION
I noticed that we didn't test `RCA_Supervised` scikit-learn compatibility

 A first problem in scikit-learn's `check_estimator` that prevented the test to pass was that `RCA_Supervised` couldn't form the default `n_chunks` number of chunks for one of the toy examples that scikit-learn had run. Fixing `num_chunks=2` ensures a normal use of the algorithm is tested (if we had put 1 chunk then it would have become a corner case)and is robuts when we cannot do a lot of chunks of data.

A second problem was just a bug when the input was int, because we couldn't substract inplace the mean to `chunk_data` (which was an array of ints, and numpy returns an error in this case).  Casting to float this object fixes it