### PR TITLE
[MRG] FIX LMNN gradient and cost function

### DIFF
--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -68,13 +68,9 @@ class _BaseITML(MahalanobisMixin):
       X = np.vstack({tuple(row) for row in pairs.reshape(-1, pairs.shape[2])})
       self.bounds_ = np.percentile(pairwise_distances(X), (5, 95))
     else:
-      bounds = check_array(bounds, allow_nd=False, ensure_min_samples=0,
-                           ensure_2d=False)
-      bounds = bounds.ravel()
-      if bounds.size != 2:
-        raise ValueError("`bounds` should be an array-like of two elements.")
+      assert len(bounds) == 2
       self.bounds_ = bounds
-    self.bounds_[self.bounds_ == 0] = 1e-9
+    self.bounds_[self.bounds_==0] = 1e-9
     # init metric
     if self.A0 is None:
       A = np.identity(pairs.shape[2])
@@ -137,7 +133,7 @@ class ITML(_BaseITML, _PairsClassifierMixin):
 
   Attributes
   ----------
-  bounds_ : `numpy.ndarray`, shape=(2,)
+  bounds_ : array-like, shape=(2,)
       Bounds on similarity, aside slack variables, s.t.
       ``d(a, b) < bounds_[0]`` for all given pairs of similar points ``a``
       and ``b``, and ``d(c, d) > bounds_[1]`` for all given pairs of
@@ -174,7 +170,7 @@ class ITML(_BaseITML, _PairsClassifierMixin):
         preprocessor.
     y: array-like, of shape (n_constraints,)
         Labels of constraints. Should be -1 for dissimilar pair, 1 for similar.
-    bounds : array-like of two numbers
+    bounds : `list` of two numbers
         Bounds on similarity, aside slack variables, s.t.
         ``d(a, b) < bounds_[0]`` for all given pairs of similar points ``a``
         and ``b``, and ``d(c, d) > bounds_[1]`` for all given pairs of
@@ -195,7 +191,7 @@ class ITML(_BaseITML, _PairsClassifierMixin):
     calibration_params = (calibration_params if calibration_params is not
                           None else dict())
     self._validate_calibration_params(**calibration_params)
-    self._fit(pairs, y, bounds=bounds)
+    self._fit(pairs, y)
     self.calibrate_threshold(pairs, y, **calibration_params)
     return self
 
@@ -205,7 +201,7 @@ class ITML_Supervised(_BaseITML, TransformerMixin):
 
   Attributes
   ----------
-  bounds_ : `numpy.ndarray`, shape=(2,)
+  bounds_ : array-like, shape=(2,)
       Bounds on similarity, aside slack variables, s.t.
       ``d(a, b) < bounds_[0]`` for all given pairs of similar points ``a``
       and ``b``, and ``d(c, d) > bounds_[1]`` for all given pairs of
@@ -278,7 +274,7 @@ class ITML_Supervised(_BaseITML, TransformerMixin):
     random_state : numpy.random.RandomState, optional
         If provided, controls random number generation.
 
-    bounds : array-like of two numbers
+    bounds : `list` of two numbers
         Bounds on similarity, aside slack variables, s.t.
         ``d(a, b) < bounds_[0]`` for all given pairs of similar points ``a``
         and ``b``, and ``d(c, d) > bounds_[1]`` for all given pairs of

--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -68,9 +68,13 @@ class _BaseITML(MahalanobisMixin):
       X = np.vstack({tuple(row) for row in pairs.reshape(-1, pairs.shape[2])})
       self.bounds_ = np.percentile(pairwise_distances(X), (5, 95))
     else:
-      assert len(bounds) == 2
+      bounds = check_array(bounds, allow_nd=False, ensure_min_samples=0,
+                           ensure_2d=False)
+      bounds = bounds.ravel()
+      if bounds.size != 2:
+        raise ValueError("`bounds` should be an array-like of two elements.")
       self.bounds_ = bounds
-    self.bounds_[self.bounds_==0] = 1e-9
+    self.bounds_[self.bounds_ == 0] = 1e-9
     # init metric
     if self.A0 is None:
       A = np.identity(pairs.shape[2])
@@ -133,7 +137,7 @@ class ITML(_BaseITML, _PairsClassifierMixin):
 
   Attributes
   ----------
-  bounds_ : array-like, shape=(2,)
+  bounds_ : `numpy.ndarray`, shape=(2,)
       Bounds on similarity, aside slack variables, s.t.
       ``d(a, b) < bounds_[0]`` for all given pairs of similar points ``a``
       and ``b``, and ``d(c, d) > bounds_[1]`` for all given pairs of
@@ -170,7 +174,7 @@ class ITML(_BaseITML, _PairsClassifierMixin):
         preprocessor.
     y: array-like, of shape (n_constraints,)
         Labels of constraints. Should be -1 for dissimilar pair, 1 for similar.
-    bounds : `list` of two numbers
+    bounds : array-like of two numbers
         Bounds on similarity, aside slack variables, s.t.
         ``d(a, b) < bounds_[0]`` for all given pairs of similar points ``a``
         and ``b``, and ``d(c, d) > bounds_[1]`` for all given pairs of
@@ -191,7 +195,7 @@ class ITML(_BaseITML, _PairsClassifierMixin):
     calibration_params = (calibration_params if calibration_params is not
                           None else dict())
     self._validate_calibration_params(**calibration_params)
-    self._fit(pairs, y)
+    self._fit(pairs, y, bounds=bounds)
     self.calibrate_threshold(pairs, y, **calibration_params)
     return self
 
@@ -201,7 +205,7 @@ class ITML_Supervised(_BaseITML, TransformerMixin):
 
   Attributes
   ----------
-  bounds_ : array-like, shape=(2,)
+  bounds_ : `numpy.ndarray`, shape=(2,)
       Bounds on similarity, aside slack variables, s.t.
       ``d(a, b) < bounds_[0]`` for all given pairs of similar points ``a``
       and ``b``, and ``d(c, d) > bounds_[1]`` for all given pairs of
@@ -274,7 +278,7 @@ class ITML_Supervised(_BaseITML, TransformerMixin):
     random_state : numpy.random.RandomState, optional
         If provided, controls random number generation.
 
-    bounds : `list` of two numbers
+    bounds : array-like of two numbers
         Bounds on similarity, aside slack variables, s.t.
         ``d(a, b) < bounds_[0]`` for all given pairs of similar points ``a``
         and ``b``, and ``d(c, d) > bounds_[1]`` for all given pairs of

--- a/metric_learn/lmnn.py
+++ b/metric_learn/lmnn.py
@@ -105,7 +105,7 @@ class python_LMNN(_base_LMNN):
       # objective than the previous L, following the gradient:
       while True:
         # the next point next_L to try out is found by a gradient step
-        L_next = L - 2 * learn_rate * G
+        L_next = L - learn_rate * G
         # we compute the objective at next point
         # we copy variables that can be modified by _loss_grad, because if we
         # retry we don t want to modify them several times
@@ -191,10 +191,12 @@ class python_LMNN(_base_LMNN):
     # do the gradient update
     assert not np.isnan(df).any()
     G = dfG * reg + df * (1 - reg)
+
+    grad = 2 * L.dot(G)
     # compute the objective function
     objective = total_active * (1 - reg)
     objective += G.flatten().dot(L.T.dot(L).flatten())
-    return G, objective, total_active, df, a1, a2
+    return grad, objective, total_active, df, a1, a2
 
   def _select_targets(self, X, label_inds):
     target_neighbors = np.empty((X.shape[0], self.k), dtype=int)

--- a/metric_learn/lmnn.py
+++ b/metric_learn/lmnn.py
@@ -191,12 +191,11 @@ class python_LMNN(_base_LMNN):
     # do the gradient update
     assert not np.isnan(df).any()
     G = dfG * reg + df * (1 - reg)
-
-    grad = 2 * L.dot(G)
+    G = L.dot(G)
     # compute the objective function
     objective = total_active * (1 - reg)
-    objective += G.flatten().dot(L.T.dot(L).flatten())
-    return grad, objective, total_active, df, a1, a2
+    objective += G.flatten().dot(L.flatten())
+    return 2 * G, objective, total_active, df, a1, a2
 
   def _select_targets(self, X, label_inds):
     target_neighbors = np.empty((X.shape[0], self.k), dtype=int)

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -2,7 +2,7 @@ import unittest
 import re
 import pytest
 import numpy as np
-from scipy.optimize import check_grad
+from scipy.optimize import check_grad, approx_fprime
 from six.moves import xrange
 from sklearn.metrics import pairwise_distances
 from sklearn.datasets import load_iris, make_classification, make_regression
@@ -21,7 +21,7 @@ from metric_learn import (LMNN, NCA, LFDA, Covariance, MLKR, MMC,
                           RCA_Supervised, MMC_Supervised, SDML)
 # Import this specially for testing.
 from metric_learn.constraints import wrap_pairs
-from metric_learn.lmnn import python_LMNN
+from metric_learn.lmnn import python_LMNN, _sum_outer_products
 
 
 def class_separation(X, labels):
@@ -119,6 +119,61 @@ class TestLMNN(MetricTestCase):
       csep = class_separation(lmnn.transform(self.iris_points),
                               self.iris_labels)
       self.assertLess(csep, 0.25)
+
+  def test_loss_grad_lbfgs(self):
+    """Test gradient of loss function
+    Assert that the gradient is almost equal to its finite differences
+    approximation.
+    """
+    rng = np.random.RandomState(42)
+    X, y = make_classification(random_state=rng)
+    L = rng.randn(rng.randint(1, X.shape[1] + 1), X.shape[1])
+    lmnn = LMNN()
+
+    k = lmnn.k
+    reg = lmnn.regularization
+
+    X, y = lmnn._prepare_inputs(X, y, dtype=float,
+                                ensure_min_samples=2)
+    num_pts, num_dims = X.shape
+    unique_labels, label_inds = np.unique(y, return_inverse=True)
+    lmnn.labels_ = np.arange(len(unique_labels))
+    lmnn.transformer_ = np.eye(num_dims)
+
+    target_neighbors = lmnn._select_targets(X, label_inds)
+    impostors = lmnn._find_impostors(target_neighbors[:, -1], X, label_inds)
+
+    # sum outer products
+    dfG = _sum_outer_products(X, target_neighbors.flatten(),
+                              np.repeat(np.arange(X.shape[0]), k))
+    df = np.zeros_like(dfG)
+
+    # storage
+    a1 = [None]*k
+    a2 = [None]*k
+    for nn_idx in xrange(k):
+      a1[nn_idx] = np.array([])
+      a2[nn_idx] = np.array([])
+
+    # initialize L
+
+    def fun(L):
+        return lmnn._loss_grad(X, L.reshape(-1, X.shape[1]), dfG, impostors, 1,
+                               k, reg,
+                               target_neighbors, df, a1, a2)[1]
+
+    def grad(L):
+        return lmnn._loss_grad(X, L.reshape(-1, X.shape[1]), dfG, impostors,
+                               1, k, reg,
+          target_neighbors, df, a1, a2)[0].ravel()
+
+    # compute relative error
+    epsilon = np.sqrt(np.finfo(float).eps)
+    rel_diff = (check_grad(fun, grad, L.ravel()) /
+                           np.linalg.norm(approx_fprime(L.ravel(), fun,
+                                                       epsilon)))
+               # np.linalg.norm(grad(L))
+    np.testing.assert_almost_equal(rel_diff, 0., decimal=5)
 
 
 def test_convergence_simple_example(capsys):
@@ -421,8 +476,10 @@ class TestNCA(MetricTestCase):
       return nca._loss_grad_lbfgs(M, X, mask)[1].ravel()
 
     # compute relative error
-    rel_diff = check_grad(fun, grad, M.ravel()) / np.linalg.norm(grad(M))
-    np.testing.assert_almost_equal(rel_diff, 0., decimal=6)
+    epsilon = np.sqrt(np.finfo(float).eps)
+    rel_diff = (check_grad(fun, grad, M.ravel()) /
+                np.linalg.norm(approx_fprime(M.ravel(), fun, epsilon)))
+    np.testing.assert_almost_equal(rel_diff, 0., decimal=10)
 
   def test_simple_example(self):
     """Test on a simple example.

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -18,7 +18,7 @@ else:
   HAS_SKGGM = True
 from metric_learn import (LMNN, NCA, LFDA, Covariance, MLKR, MMC,
                           LSML_Supervised, ITML_Supervised, SDML_Supervised,
-                          RCA_Supervised, MMC_Supervised, SDML, ITML)
+                          RCA_Supervised, MMC_Supervised, SDML)
 # Import this specially for testing.
 from metric_learn.constraints import wrap_pairs
 from metric_learn.lmnn import python_LMNN, _sum_outer_products
@@ -107,43 +107,6 @@ class TestITML(MetricTestCase):
            'removed in 0.6.0. Use the "bounds" parameter of this '
            'fit method instead.')
     assert_warns_message(DeprecationWarning, msg, itml_supervised.fit, X, y)
-
-
-@pytest.mark.parametrize('bounds', [None, (20., 100.), [20., 100.],
-                                    np.array([20., 100.]),
-                                    np.array([[20., 100.]]),
-                                    np.array([[20], [100]])])
-def test_bounds_parameters_valid(bounds):
-  """Asserts that we can provide any array-like of two elements as bounds,
-  and that the attribute bound_ is a numpy array"""
-
-  pairs = np.array([[[-10., 0.], [10., 0.]], [[0., 50.], [0., -60]]])
-  y_pairs = [1, -1]
-  itml = ITML()
-  itml.fit(pairs, y_pairs, bounds=bounds)
-
-  X = np.array([[0, 0], [0, 1], [2, 0], [2, 1]])
-  y = np.array([1, 0, 1, 0])
-  itml_supervised = ITML_Supervised()
-  itml_supervised.fit(X, y, bounds=bounds)
-
-
-@pytest.mark.parametrize('bounds', ['weird', ['weird1', 'weird2'],
-                                    np.array([1, 2, 3])])
-def test_bounds_parameters_invalid(bounds):
-  """Assert that if a non array-like is put for bounds, or an array-like
-  of length different than 2, an error is returned"""
-  pairs = np.array([[[-10., 0.], [10., 0.]], [[0., 50.], [0., -60]]])
-  y_pairs = [1, -1]
-  itml = ITML()
-  with pytest.raises(Exception):
-    itml.fit(pairs, y_pairs, bounds=bounds)
-
-  X = np.array([[0, 0], [0, 1], [2, 0], [2, 1]])
-  y = np.array([1, 0, 1, 0])
-  itml_supervised = ITML_Supervised()
-  with pytest.raises(Exception):
-    itml_supervised.fit(X, y, bounds=bounds)
 
 
 class TestLMNN(MetricTestCase):

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -156,20 +156,16 @@ class TestLMNN(MetricTestCase):
       a2[nn_idx] = np.array([])
 
     # initialize L
+    def loss_grad(flat_L):
+      return lmnn._loss_grad(X, flat_L.reshape(-1, X.shape[1]), dfG, impostors,
+                             1, k, reg, target_neighbors, df.copy(),
+                             list(a1), list(a2))
 
-    def fun(L):
-        # we copy variables that can be modified by _loss_grad, because we
-        # want to have the same result when applying the function twice
-        return lmnn._loss_grad(X, L.reshape(-1, X.shape[1]), dfG, impostors,
-                               1, k, reg, target_neighbors, df.copy(),
-                               list(a1), list(a2))[1]
+    def fun(x):
+      loss_grad(x)[1]
 
-    def grad(L):
-        # we copy variables that can be modified by _loss_grad, because we
-        # want to have the same result when applying the function twice
-        return lmnn._loss_grad(X, L.reshape(-1, X.shape[1]), dfG, impostors,
-                               1, k, reg, target_neighbors, df.copy(),
-                               list(a1), list(a2))[0].ravel()
+    def grad(x):
+      loss_grad(x)[0].ravel()
 
     # compute relative error
     epsilon = np.sqrt(np.finfo(float).eps)
@@ -212,19 +208,9 @@ def test_toy_ex_lmnn(X, y, loss):
     a1[nn_idx] = np.array([])
     a2[nn_idx] = np.array([])
 
-  # initialize L
-
-  def fun(L):
-      return lmnn._loss_grad(X, L.reshape(-1, X.shape[1]), dfG, impostors, 1,
-                             k, reg,
-                             target_neighbors, df, a1, a2)[1]
-
-  def grad(L):
-      return lmnn._loss_grad(X, L.reshape(-1, X.shape[1]), dfG, impostors, 1,
-                             k, reg, target_neighbors, df, a1, a2)[0].ravel()
-
-  # compute relative error
-  assert fun(L) == loss
+  #  assert that the loss equals the one computed by hand
+  assert lmnn._loss_grad(X, L.reshape(-1, X.shape[1]), dfG, impostors, 1, k,
+                         reg, target_neighbors, df, a1, a2)[1] == loss
 
 
 def test_convergence_simple_example(capsys):

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -18,7 +18,7 @@ else:
   HAS_SKGGM = True
 from metric_learn import (LMNN, NCA, LFDA, Covariance, MLKR, MMC,
                           LSML_Supervised, ITML_Supervised, SDML_Supervised,
-                          RCA_Supervised, MMC_Supervised, SDML)
+                          RCA_Supervised, MMC_Supervised, SDML, ITML)
 # Import this specially for testing.
 from metric_learn.constraints import wrap_pairs
 from metric_learn.lmnn import python_LMNN, _sum_outer_products
@@ -107,6 +107,43 @@ class TestITML(MetricTestCase):
            'removed in 0.6.0. Use the "bounds" parameter of this '
            'fit method instead.')
     assert_warns_message(DeprecationWarning, msg, itml_supervised.fit, X, y)
+
+
+@pytest.mark.parametrize('bounds', [None, (20., 100.), [20., 100.],
+                                    np.array([20., 100.]),
+                                    np.array([[20., 100.]]),
+                                    np.array([[20], [100]])])
+def test_bounds_parameters_valid(bounds):
+  """Asserts that we can provide any array-like of two elements as bounds,
+  and that the attribute bound_ is a numpy array"""
+
+  pairs = np.array([[[-10., 0.], [10., 0.]], [[0., 50.], [0., -60]]])
+  y_pairs = [1, -1]
+  itml = ITML()
+  itml.fit(pairs, y_pairs, bounds=bounds)
+
+  X = np.array([[0, 0], [0, 1], [2, 0], [2, 1]])
+  y = np.array([1, 0, 1, 0])
+  itml_supervised = ITML_Supervised()
+  itml_supervised.fit(X, y, bounds=bounds)
+
+
+@pytest.mark.parametrize('bounds', ['weird', ['weird1', 'weird2'],
+                                    np.array([1, 2, 3])])
+def test_bounds_parameters_invalid(bounds):
+  """Assert that if a non array-like is put for bounds, or an array-like
+  of length different than 2, an error is returned"""
+  pairs = np.array([[[-10., 0.], [10., 0.]], [[0., 50.], [0., -60]]])
+  y_pairs = [1, -1]
+  itml = ITML()
+  with pytest.raises(Exception):
+    itml.fit(pairs, y_pairs, bounds=bounds)
+
+  X = np.array([[0, 0], [0, 1], [2, 0], [2, 1]])
+  y = np.array([1, 0, 1, 0])
+  itml_supervised = ITML_Supervised()
+  with pytest.raises(Exception):
+    itml_supervised.fit(X, y, bounds=bounds)
 
 
 class TestLMNN(MetricTestCase):

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -162,10 +162,10 @@ class TestLMNN(MetricTestCase):
                              list(a1), list(a2))
 
     def fun(x):
-      loss_grad(x)[1]
+      return loss_grad(x)[1]
 
     def grad(x):
-      loss_grad(x)[0].ravel()
+      return loss_grad(x)[0].ravel()
 
     # compute relative error
     epsilon = np.sqrt(np.finfo(float).eps)

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -530,7 +530,7 @@ class TestNCA(MetricTestCase):
     epsilon = np.sqrt(np.finfo(float).eps)
     rel_diff = (check_grad(fun, grad, M.ravel()) /
                 np.linalg.norm(approx_fprime(M.ravel(), fun, epsilon)))
-    np.testing.assert_almost_equal(rel_diff, 0., decimal=10)
+    np.testing.assert_almost_equal(rel_diff, 0., decimal=6)
 
   def test_simple_example(self):
     """Test on a simple example.


### PR DESCRIPTION
Fixes #46 
There seems to be problems in LMNN, that we might want to fix for the next release: 

(Note: to find out what to do we can also compare to https://github.com/scikit-learn/scikit-learn/pull/8602 )

-  Looking into this line the gradient seems to be of the shape of an outer product of Xs (when it should be of the shape of L) (see https://github.com/metric-learn/metric-learn/pull/193#issuecomment-489228612). (There might be a dot product with L missing:
(cf. https://github.com/scikit-learn/scikit-learn/pull/8602/files#diff2914dd42441ed8b594e69b2fe04d23f5R762)) This blocks PR #193:

https://github.com/metric-learn/metric-learn/blob/d4badc8adc0a8ce6689dd9a95e89181efaf5ee24/metric_learn/lmnn.py#L196

- Some part of the loss function seems to be an integer count, when it should be the hinge loss ? as suggested by #46: 

https://github.com/metric-learn/metric-learn/blob/d4badc8adc0a8ce6689dd9a95e89181efaf5ee24/metric_learn/lmnn.py#L198

I created a test that should pass when this is fixed (like the one in scikit-learn's PR)

I'll look into it, but I'm not yet that familiar with LMNN so you might know how to fix it
