### PR TITLE
[MRG] Use pseudo-inverse in Covariance

### DIFF
--- a/metric_learn/covariance.py
+++ b/metric_learn/covariance.py
@@ -14,6 +14,7 @@ from sklearn.base import TransformerMixin
 
 from .base_metric import MahalanobisMixin
 from ._util import transformer_from_metric
+import scipy
 
 
 class Covariance(MahalanobisMixin, TransformerMixin):
@@ -35,11 +36,11 @@ class Covariance(MahalanobisMixin, TransformerMixin):
     y : unused
     """
     X = self._prepare_inputs(X, ensure_min_samples=2)
-    M = np.atleast2d(np.cov(X, rowvar = False))
+    M = np.atleast_2d(np.cov(X, rowvar=False))
     if len(M) == 1:
-      M = 1./M
+      M = 1. / M
     else:
-      M = np.linalg.pinvh(M)
+      M = scipy.linalg.pinvh(M)
 
     self.transformer_ = transformer_from_metric(np.atleast_2d(M))
     return self

--- a/metric_learn/covariance.py
+++ b/metric_learn/covariance.py
@@ -37,7 +37,7 @@ class Covariance(MahalanobisMixin, TransformerMixin):
     """
     X = self._prepare_inputs(X, ensure_min_samples=2)
     M = np.atleast_2d(np.cov(X, rowvar=False))
-    if len(M) == 1:
+    if M.size == 1:
       M = 1. / M
     else:
       M = scipy.linalg.pinvh(M)

--- a/metric_learn/covariance.py
+++ b/metric_learn/covariance.py
@@ -10,11 +10,11 @@ On the Generalized Distance in Statistics, P.C.Mahalanobis, 1936
 
 from __future__ import absolute_import
 import numpy as np
+import scipy
 from sklearn.base import TransformerMixin
 
 from .base_metric import MahalanobisMixin
 from ._util import transformer_from_metric
-import scipy
 
 
 class Covariance(MahalanobisMixin, TransformerMixin):

--- a/metric_learn/covariance.py
+++ b/metric_learn/covariance.py
@@ -35,11 +35,11 @@ class Covariance(MahalanobisMixin, TransformerMixin):
     y : unused
     """
     X = self._prepare_inputs(X, ensure_min_samples=2)
-    M = np.cov(X, rowvar = False)
-    if M.ndim == 0:
+    M = np.atleast2d(np.cov(X, rowvar = False))
+    if len(M) == 1:
       M = 1./M
     else:
-      M = np.linalg.inv(M)
+      M = np.linalg.pinvh(M)
 
     self.transformer_ = transformer_from_metric(np.atleast_2d(M))
     return self

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -6,7 +6,8 @@ from scipy.optimize import check_grad
 from six.moves import xrange
 from sklearn.metrics import pairwise_distances
 from sklearn.datasets import load_iris, make_classification, make_regression
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import (assert_array_almost_equal, assert_array_equal,
+                           assert_allclose)
 from sklearn.utils.testing import assert_warns_message
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils.validation import check_X_y
@@ -52,6 +53,23 @@ class TestCovariance(MetricTestCase):
     csep = class_separation(cov.transform(self.iris_points), self.iris_labels)
     # deterministic result
     self.assertAlmostEqual(csep, 0.72981476)
+
+  def test_singular_returns_pseudo_inverse(self):
+    """Checks that if the input covariance matrix is singular, we return
+    the pseudo inverse"""
+    X, y = load_iris(return_X_y=True)
+    # We add a virtual column that is a linear combination of the other
+    # columns so that the covariance matrix will be singular
+    X = np.concatenate([X, X[:, :2].dot([[2], [3]])], axis=1)
+    cov_matrix = np.cov(X, rowvar=False)
+    covariance = Covariance()
+    covariance.fit(X)
+    pseudo_inverse = covariance.get_mahalanobis_matrix()
+    # here is the definition of a pseudo inverse according to wikipedia:
+    assert_allclose(cov_matrix.dot(pseudo_inverse).dot(cov_matrix),
+                    cov_matrix)
+    assert_allclose(pseudo_inverse.dot(cov_matrix).dot(pseudo_inverse),
+                    pseudo_inverse)
 
 
 class TestLSML(MetricTestCase):


### PR DESCRIPTION
Fixes #204 

This PR uses the pseudo inverse in Covariance, rather than the inverse. See https://github.com/metric-learn/metric-learn/issues/204#issuecomment-492336040
