### PR TITLE
[MRG] fix quadruplets decision_function

### DIFF
--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -618,6 +618,9 @@ class _QuadrupletsClassifierMixin(BaseMetricLearner):
     decision_function : `numpy.ndarray` of floats, shape=(n_constraints,)
       Metric differences.
     """
+    quadruplets = check_input(quadruplets, type_of_inputs='tuples',
+                              preprocessor=self.preprocessor_,
+                              estimator=self, tuple_size=self._tuple_size)
     return (self.score_pairs(quadruplets[:, 2:]) -
             self.score_pairs(quadruplets[:, :2]))
 

--- a/test/test_sklearn_compat.py
+++ b/test/test_sklearn_compat.py
@@ -135,9 +135,9 @@ def test_array_like_inputs(estimator, build_dataset, with_preprocessor):
   input_data, labels, preprocessor, X = build_dataset(with_preprocessor)
 
   # we subsample the data for the test to be more efficient
-  input_data, labels = input_data[5:], labels[5:]
-  X = X[5:]
-  
+  input_data, labels = input_data[:30], labels[:30]
+  X = X[:10]
+
   estimator = clone(estimator)
   estimator.set_params(preprocessor=preprocessor)
   set_random_state(estimator)

--- a/test/test_sklearn_compat.py
+++ b/test/test_sklearn_compat.py
@@ -136,7 +136,7 @@ def test_array_like_inputs(estimator, build_dataset, with_preprocessor):
 
   # we subsample the data for the test to be more efficient
   input_data, _, labels, _ = train_test_split(input_data, labels,
-                                              train_size=20)
+                                              train_size=30)
   X = X[:10]
 
   estimator = clone(estimator)

--- a/test/test_sklearn_compat.py
+++ b/test/test_sklearn_compat.py
@@ -135,7 +135,8 @@ def test_array_like_inputs(estimator, build_dataset, with_preprocessor):
   input_data, labels, preprocessor, X = build_dataset(with_preprocessor)
 
   # we subsample the data for the test to be more efficient
-  input_data, labels = input_data[:30], labels[:30]
+  input_data, _, labels, _ = train_test_split(input_data, labels,
+                                              train_size=20)
   X = X[:10]
 
   estimator = clone(estimator)

--- a/test/test_sklearn_compat.py
+++ b/test/test_sklearn_compat.py
@@ -136,7 +136,7 @@ def test_array_like_inputs(estimator, build_dataset, with_preprocessor):
 
   # we subsample the data for the test to be more efficient
   input_data, _, labels, _ = train_test_split(input_data, labels,
-                                              train_size=30)
+                                              train_size=20)
   X = X[:10]
 
   estimator = clone(estimator)

--- a/test/test_sklearn_compat.py
+++ b/test/test_sklearn_compat.py
@@ -133,6 +133,11 @@ def test_array_like_inputs(estimator, build_dataset, with_preprocessor):
   """Test that metric-learners can have as input (of all functions that are
   applied on data) any array-like object."""
   input_data, labels, preprocessor, X = build_dataset(with_preprocessor)
+
+  # we subsample the data for the test to be more efficient
+  input_data, labels = input_data[5:], labels[5:]
+  X = X[5:]
+  
   estimator = clone(estimator)
   estimator.set_params(preprocessor=preprocessor)
   set_random_state(estimator)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -118,7 +118,7 @@ classifiers = [(Covariance(), build_classification),
                (ITML_Supervised(max_iter=5), build_classification),
                (LSML_Supervised(), build_classification),
                (MMC_Supervised(max_iter=5), build_classification),
-               (RCA_Supervised(num_chunks=10), build_classification),
+               (RCA_Supervised(num_chunks=5), build_classification),
                (SDML_Supervised(prior='identity', balance_param=1e-5),
                build_classification)]
 ids_classifiers = list(map(lambda x: x.__class__.__name__,


### PR DESCRIPTION
I just realized there was a pb with `decision_function` for quadruplets, since it didn't work on list of lists of lists (instead of 3D arrays). It made me realize that we don't have integration test for these array-like inputs (althought we had extensive unit tests of `check_input` functions). Here is a fix. It adds a significant test time (15s, because it tests all possibilities with reasonable size datasets), but it's like other similar tests, it's hard to find smaller datasets since sometimes the algorithms do wrong on them. I've opened a separate issue (#218) for reducing the time of tests, so if everything is OK regarding everything but the time consideration, I guess we can merge 