### PR TITLE
[MRG] Fix quadruplets scoring

### DIFF
--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -641,4 +641,9 @@ class _QuadrupletsClassifierMixin(BaseMetricLearner):
     score : float
       The quadruplets score.
     """
-    return np.mean((self.predict(quadruplets) + 1) / 2)
+    # Since the prediction is a vector of values in {-1, +1}, we need to
+    # rescale them to {0, 1} to compute the accuracy using the mean (because
+    # then 1 means a correctly classified result (pairs are in the right
+    # order), and a 0 an incorrectly classified result (pairs are in the
+    # wrong order).
+    return self.predict(quadruplets).mean() / 2 + 0.5

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -641,4 +641,4 @@ class _QuadrupletsClassifierMixin(BaseMetricLearner):
     score : float
       The quadruplets score.
     """
-    return - np.mean(self.predict(quadruplets))
+    return np.mean((self.predict(quadruplets) + 1) / 2)


### PR DESCRIPTION
There was a problem with scoring in LSML: this PR fixes it (and adds a non-regression test as well as a small test for prediction for pairs learners)