### PR TITLE
[WIP] update impostors

### DIFF
--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -336,11 +336,10 @@ def test_loss_func(capsys):
       self.y = y
       return super(LMNN_nonperformant, self).fit(X, y)
 
-    def _loss_grad(self, X, L, dfG, impostors, it, k, reg, target_neighbors,
-                   df, a1, a2):
+    def _loss_grad(self, X, L, y, dfG, it, k, reg, target_neighbors):
       grad, loss, total_active = loss_fn(L.ravel(), X, self.y,
                                          target_neighbors, self.regularization)
-      return grad, loss, total_active, [], [], []
+      return grad, loss, total_active
 
   # test that the objective function never has twice the same value
   # see https://github.com/metric-learn/metric-learn/issues/88

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -307,6 +307,8 @@ def test_loss_func(capsys):
       return 0, 0
 
   def loss_fn(L, X, y, target_neighbors, regularization):
+    # warning to self: this is probably wrong, see test on the thing that was
+    # before
      L = L.reshape(-1, X.shape[1])
      Lx = np.dot(X, L.T)
      loss = 0

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -2,9 +2,10 @@ import unittest
 import re
 import pytest
 import numpy as np
+import scipy
 from scipy.optimize import check_grad, approx_fprime
 from six.moves import xrange
-from sklearn.metrics import pairwise_distances
+from sklearn.metrics import pairwise_distances, euclidean_distances
 from sklearn.datasets import (load_iris, make_classification, make_regression,
                               make_spd_matrix, make_blobs)
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
@@ -300,6 +301,10 @@ def test_loss_func(capsys):
   #  the beginning and they decrease
   # TODO: ideally we would like to do a test where the number of active
   #  constraints decrease
+  # TODO: apparently it worked with master, when master does not recomputes
+  #  the impostors, so see if I could not improve this test to ensure it
+  #  tests well impostors recomputation (or at least if the impostors at
+  #  init are not all the impostors)
   def hinge(a):
     if a > 0:
       return a, 1
@@ -317,7 +322,7 @@ def test_loss_func(capsys):
      for i in range(X.shape[0]):
        for j in target_neighbors[i]:
          loss += (1 - regularization) * np.sum((Lx[i] - Lx[j])**2)
-         grad += (1 - regularization) * (Lx[i] - Lx[j]).T.dot(X[i] - X[j])
+         grad += (1 - regularization) * np.outer(Lx[i] - Lx[j], X[i] - X[j])
          for l in range(X.shape[0]):
            if y[i] != y[l]:
              hin, active = hinge(1 + np.sum((Lx[i] - Lx[j])**2) -
@@ -327,10 +332,38 @@ def test_loss_func(capsys):
              if active:
                loss += regularization * hin
                grad += (regularization *
-                        ((Lx[i] - Lx[j]).T.dot(X[i] - X[j])
-                         - (Lx[i] - Lx[l]).T.dot(X[i] - X[l])))
-     grad *= 2
+                        (np.outer(Lx[i] - Lx[j], X[i] - X[j])
+                         - np.outer(Lx[i] - Lx[l], X[i] - X[l])))
+     grad = 2 * grad
      return grad, loss, total_active
+
+  # we check that the gradient we have computed in the test is indeed the
+  # true gradient on a toy example:
+  X, y = make_classification(random_state=42, class_sep=0.1, n_features=20)
+
+  def _select_targets(X, y, k):
+    target_neighbors = np.empty((X.shape[0], k), dtype=int)
+    for label in np.unique(y):
+      inds, = np.nonzero(y == label)
+      dd = euclidean_distances(X[inds], squared=True)
+      np.fill_diagonal(dd, np.inf)
+      nn = np.argsort(dd)[..., :k]
+      target_neighbors[inds] = inds[nn]
+    return target_neighbors
+
+  target_neighbors = _select_targets(X, y, 2)
+  regularization = 0.5
+  x0 = np.random.randn(5, 20)
+
+  def loss(x0):
+    return loss_fn(x0.reshape(-1, X.shape[1]), X, y, target_neighbors,
+                   regularization)[1]
+
+  def grad(x0):
+    return loss_fn(x0.reshape(-1, X.shape[1]), X, y, target_neighbors,
+                   regularization)[0].ravel()
+
+  scipy.optimize.check_grad(loss, grad, x0.ravel())
 
   class LMNN_nonperformant(LMNN):
 


### PR DESCRIPTION
See https://github.com/metric-learn/metric-learn/pull/208#issuecomment-503002436

This fixes the TODO at top of LMNN: it recomputes the impostors at each step

This is a WIP and not tested for now (though it works on a small example but it's not efficient at all, more like a first atempt to do that with very few code change)

Note that in the scikit-learn PR, they do update the impostors https://github.com/scikit-learn/scikit-learn/pull/8602, but they only keep a maximum number of impostors

We also need to decide whether we want impostors updating to be an option or to be always there

Note: for now, I update the impostors, but it's not at all efficient, because the distances comparisons are re-done just after, when computing the active constraints. The advantage of computing impostors is to search for active constraints only amongst them. An idea could be to do the following (I've not thought of it all the way through so it might be wrong):
- for the furthest target neighbors: we compute the impostors (by comparing among all/[a max number of impostors] distances between different labels points and target neighbors)
- amongst those only, we compute the impostors wrt the second furthest neighbor (because if a pair is not an impostor wrt to the furthest target neighbor, it's not either for the second further)
etc 

Note: a quick solution that could be used as a first improvement (and the real improvement would be in V0.6.0) would be to have an option to either use the impostors computed at the beginning, or to use all impostors possible (i.e. all pairs of points of different labels) (which can very easily be implemented in the `find_impostors` function