### PR TITLE
[MRG] Fix random state in algorithms

### DIFF
--- a/metric_learn/lmnn.py
+++ b/metric_learn/lmnn.py
@@ -210,7 +210,7 @@ class LMNN(MahalanobisMixin, TransformerMixin):
       init = self.init
     self.components_ = _initialize_components(output_dim, X, y, init,
                                               self.verbose,
-                                              self.random_state)
+                                              random_state=self.random_state)
     required_k = np.bincount(label_inds).min()
     if self.k > required_k:
       raise ValueError('not enough class labels for specified k'

--- a/metric_learn/lsml.py
+++ b/metric_learn/lsml.py
@@ -56,9 +56,8 @@ class _BaseLSML(MahalanobisMixin):
     else:
       prior = self.prior
     M, prior_inv = _initialize_metric_mahalanobis(quadruplets, prior,
-                                                  return_inverse=True,
-                                                  strict_pd=True,
-                                                  matrix_name='prior')
+       return_inverse=True, strict_pd=True, matrix_name='prior',
+       random_state=self.random_state)
 
     step_sizes = np.logspace(-10, 0, 10)
     # Keep track of the best step size and the loss at that step.

--- a/metric_learn/nca.py
+++ b/metric_learn/nca.py
@@ -174,7 +174,8 @@ class NCA(MahalanobisMixin, TransformerMixin):
       init = 'auto'
     else:
       init = self.init
-    A = _initialize_components(n_components, X, labels, init, self.verbose)
+    A = _initialize_components(n_components, X, labels, init, self.verbose,
+                               self.random_state)
 
     # Run NCA
     mask = labels[:, np.newaxis] == labels[np.newaxis, :]

--- a/metric_learn/sdml.py
+++ b/metric_learn/sdml.py
@@ -69,9 +69,8 @@ class _BaseSDML(MahalanobisMixin):
     else:
       prior = self.prior
     _, prior_inv = _initialize_metric_mahalanobis(pairs, prior,
-                                                  return_inverse=True,
-                                                  strict_pd=True,
-                                                  matrix_name='prior')
+       return_inverse=True, strict_pd=True, matrix_name='prior',
+       random_state=self.random_state)
     diff = pairs[:, 0] - pairs[:, 1]
     loss_matrix = (diff.T * y).dot(diff)
     emp_cov = prior_inv + self.balance_param * loss_matrix


### PR DESCRIPTION
This sets a random state in the algorithms that didn't have it set, and tests it. See https://github.com/metric-learn/metric-learn/pull/232#issuecomment-508757860 